### PR TITLE
ODATA-1396 - new - ordinalIndex can be negative, avoid empty optional segments

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -98,12 +98,12 @@ odataRelativeUri = '$batch'  [ "?" batchOptions ]
 ; 1. Resource Path
 ;------------------------------------------------------------------------------
 
-resourcePath = entitySetName                  collectionnavigation
-             / singletonEntity                singlenavigation
+resourcePath = entitySetName                  [ collectionNavigation ]
+             / singletonEntity                [ singleNavigation ]
              / actionImportCall 
-             / entityColFunctionImportCall    collectionnavigation
-             / entityFunctionImportCall       singlenavigation 
-             / complexColFunctionImportCall   complexcolPath 
+             / entityColFunctionImportCall    [ collectionNavigation ]
+             / entityFunctionImportCall       [ singleNavigation ]
+             / complexColFunctionImportCall   [ complexcolPath ]
              / complexFunctionImportCall      complexPath 
              / primitiveColFunctionImportCall [ collectionPath ] 
              / primitiveFunctionImportCall    [ primitivePath ] 
@@ -111,9 +111,11 @@ resourcePath = entitySetName                  collectionnavigation
              / crossjoin                      [ querySegment ]
              / '$all'                         [ "/" optionallyQualifiedEntityTypeName ]
 
-collectionNavigation = [ "/" optionallyQualifiedEntityTypeName ] [ collectionNavPath ]
-collectionNavPath    = keyPredicate singlenavigation
-                     / filterInPath collectionNavigation
+collectionNavigation = collectionNavPath
+                     / "/" optionallyQualifiedEntityTypeName [ collectionNavPath ]
+
+collectionNavPath    = keyPredicate [ singleNavigation ]
+                     / filterInPath [ collectionNavigation ]
                      / each [ boundOperation ]
                      / boundOperation
                      / count
@@ -129,7 +131,10 @@ keyPropertyAlias = odataIdentifier
 keyPathSegments  = 1*( "/" keyPathLiteral )
 keyPathLiteral   = *pchar
 
-singleNavigation = [ "/" optionallyQualifiedEntityTypeName ] 
+singleNavigation = singleNavPath
+                 / "/" optionallyQualifiedEntityTypeName [ singleNavPath ]
+
+singleNavPath = [ "/" optionallyQualifiedEntityTypeName ] 
                    [ "/" propertyPath
                    / boundOperation
                    / ref 
@@ -137,9 +142,9 @@ singleNavigation = [ "/" optionallyQualifiedEntityTypeName ]
                    / querySegment
                    ]
 
-propertyPath = entityColNavigationProperty collectionNavigation
-             / entityNavigationProperty    singlenavigation
-             / complexColProperty          complexcolPath
+propertyPath = entityColNavigationProperty [ collectionNavigation ]
+             / entityNavigationProperty    [ singleNavigation ]
+             / complexColProperty          [ complexColPath ]
              / complexProperty             complexPath
              / primitiveColProperty        [ collectionPath ]
              / primitiveProperty           [ primitivePath ]
@@ -149,7 +154,8 @@ collectionPath = count / boundOperation / ordinalIndex / querySegment
 
 primitivePath  = value / boundOperation / querySegment
 
-complexColPath = [ "/" optionallyQualifiedComplexTypeName ] [ collectionPath ]
+complexColPath = collectionPath 
+               / "/" optionallyQualifiedComplexTypeName [ collectionPath ]
 
 complexPath    = [ "/" optionallyQualifiedComplexTypeName ] 
                  [ "/" propertyPath 
@@ -172,9 +178,9 @@ ordinalIndex = "/" [ "-" ] 1*DIGIT
 ; matches the type of the first parameter of the action or function being called.
 ; Note that the rule name reflects the return type of the function.
 boundOperation = "/" ( boundActionCall
-                     / boundEntityColFunctionCall    collectionnavigation
-                     / boundEntityFunctionCall       singlenavigation 
-                     / boundComplexColFunctionCall   complexcolPath 
+                     / boundEntityColFunctionCall    [ collectionnavigation ]
+                     / boundEntityFunctionCall       [ singleNavigation ]
+                     / boundComplexColFunctionCall   [ complexColPath ]
                      / boundComplexFunctionCall      complexPath
                      / boundPrimitiveColFunctionCall [ collectionPath ] 
                      / boundPrimitiveFunctionCall    [ primitivePath ] 

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -99,12 +99,12 @@ odataRelativeUri = '$batch'  [ "?" batchOptions ]
 ;------------------------------------------------------------------------------
 
 resourcePath = entitySetName                  [ collectionNavigation ] 
-             / singletonEntity                [ singleNavigation ] 
+             / singletonEntity                [ singleNavigation ]  
              / actionImportCall 
-             / entityColFunctionImportCall    [ collectionNavigation ]
-             / entityFunctionImportCall       [ singleNavigation ]
+             / entityColFunctionImportCall    [ collectionNavigation ] 
+             / entityFunctionImportCall       [ singleNavigation ] 
              / complexColFunctionImportCall   [ complexColPath ] 
-             / complexFunctionImportCall      [ complexPath ]
+             / complexFunctionImportCall      [ complexPath ] 
              / primitiveColFunctionImportCall [ collectionPath ] 
              / primitiveFunctionImportCall    [ primitivePath ] 
              / functionImportCallNoParens     [ querySegment ]
@@ -134,13 +134,11 @@ keyPathLiteral   = *pchar
 singleNavigation = singleNavPath
                  / "/" optionallyQualifiedEntityTypeName [ singleNavPath ]
 
-singleNavPath = [ "/" optionallyQualifiedEntityTypeName ] 
-                   [ "/" propertyPath
-                   / boundOperation
-                   / ref 
-                   / value  ; request the media resource of a media entity 
-                   / querySegment
-                   ]
+singleNavPath = "/" propertyPath
+              / boundOperation
+              / ref 
+              / value  ; request the media resource of a media entity 
+              / querySegment
 
 propertyPath = entityColNavigationProperty [ collectionNavigation ]
              / entityNavigationProperty    [ singleNavigation ]
@@ -179,9 +177,9 @@ ordinalIndex = "/" [ "-" ] 1*DIGIT
 ; matches the type of the first parameter of the action or function being called.
 ; Note that the rule name reflects the return type of the function.
 boundOperation = "/" ( boundActionCall
-                     / boundEntityColFunctionCall    [ collectionnavigation ]
+                     / boundEntityColFunctionCall    [ collectionNavigation ] 
                      / boundEntityFunctionCall       [ singleNavigation ]
-                     / boundComplexColFunctionCall   [ complexColPath ]
+                     / boundComplexColFunctionCall   [ complexColPath ] 
                      / boundComplexFunctionCall      [ complexPath ]
                      / boundPrimitiveColFunctionCall [ collectionPath ] 
                      / boundPrimitiveFunctionCall    [ primitivePath ] 

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -103,9 +103,9 @@ resourcePath = entitySetName                  collectionnavigation
              / actionImportCall 
              / entityColFunctionImportCall    collectionnavigation
              / entityFunctionImportCall       singlenavigation 
-             / complexColFunctionImportCall   [ complexColPath ] 
-             / complexFunctionImportCall      [ complexPath ] 
-             / primitiveColFunctionImportCall [ primitiveColPath ] 
+             / complexColFunctionImportCall   complexcolPath 
+             / complexFunctionImportCall      complexPath 
+             / primitiveColFunctionImportCall [ collectionPath ] 
              / primitiveFunctionImportCall    [ primitivePath ] 
              / functionImportCallNoParens     [ querySegment ]
              / crossjoin                      [ querySegment ]
@@ -139,18 +139,17 @@ singleNavigation = [ "/" optionallyQualifiedEntityTypeName ]
 
 propertyPath = entityColNavigationProperty collectionNavigation
              / entityNavigationProperty    singlenavigation
-             / complexColProperty          [ complexColPath ]
-             / complexProperty             [ complexPath ]
-             / primitiveColProperty        [ primitiveColPath ]
+             / complexColProperty          complexcolPath
+             / complexProperty             complexPath
+             / primitiveColProperty        [ collectionPath ]
              / primitiveProperty           [ primitivePath ]
              / streamProperty              [ boundOperation ]
 
-primitiveColPath = count / boundOperation / ordinalIndex / querySegment
+collectionPath = count / boundOperation / ordinalIndex / querySegment
 
 primitivePath  = value / boundOperation / querySegment
 
-complexColPath = ordinalIndex
-               / [ "/" optionallyQualifiedComplexTypeName ] [ count / boundOperation / querySegment ]
+complexColPath = [ "/" optionallyQualifiedComplexTypeName ] [ collectionPath ]
 
 complexPath    = [ "/" optionallyQualifiedComplexTypeName ] 
                  [ "/" propertyPath 
@@ -175,9 +174,9 @@ ordinalIndex = "/" [ "-" ] 1*DIGIT
 boundOperation = "/" ( boundActionCall
                      / boundEntityColFunctionCall    collectionnavigation
                      / boundEntityFunctionCall       singlenavigation 
-                     / boundComplexColFunctionCall   [ complexColPath ] 
-                     / boundComplexFunctionCall      [ complexPath ]
-                     / boundPrimitiveColFunctionCall [ primitiveColPath ] 
+                     / boundComplexColFunctionCall   complexcolPath 
+                     / boundComplexFunctionCall      complexPath
+                     / boundPrimitiveColFunctionCall [ collectionPath ] 
                      / boundPrimitiveFunctionCall    [ primitivePath ] 
                      / boundFunctionCallNoParens     [ querySegment ]
                      )

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -98,13 +98,13 @@ odataRelativeUri = '$batch'  [ "?" batchOptions ]
 ; 1. Resource Path
 ;------------------------------------------------------------------------------
 
-resourcePath = entitySetName                  [ collectionNavigation ]
-             / singletonEntity                [ singleNavigation ]
+resourcePath = entitySetName                  [ collectionNavigation ] 
+             / singletonEntity                [ singleNavigation ] 
              / actionImportCall 
              / entityColFunctionImportCall    [ collectionNavigation ]
              / entityFunctionImportCall       [ singleNavigation ]
-             / complexColFunctionImportCall   [ complexcolPath ]
-             / complexFunctionImportCall      complexPath 
+             / complexColFunctionImportCall   [ complexColPath ] 
+             / complexFunctionImportCall      [ complexPath ]
              / primitiveColFunctionImportCall [ collectionPath ] 
              / primitiveFunctionImportCall    [ primitivePath ] 
              / functionImportCallNoParens     [ querySegment ]
@@ -145,7 +145,7 @@ singleNavPath = [ "/" optionallyQualifiedEntityTypeName ]
 propertyPath = entityColNavigationProperty [ collectionNavigation ]
              / entityNavigationProperty    [ singleNavigation ]
              / complexColProperty          [ complexColPath ]
-             / complexProperty             complexPath
+             / complexProperty             [ complexPath ]
              / primitiveColProperty        [ collectionPath ]
              / primitiveProperty           [ primitivePath ]
              / streamProperty              [ boundOperation ]
@@ -157,11 +157,12 @@ primitivePath  = value / boundOperation / querySegment
 complexColPath = collectionPath 
                / "/" optionallyQualifiedComplexTypeName [ collectionPath ]
 
-complexPath    = [ "/" optionallyQualifiedComplexTypeName ] 
-                 [ "/" propertyPath 
-                 / boundOperation
-                 / querySegment
-                 ]
+complexPath = complexNavPath 
+            / "/" optionallyQualifiedComplexTypeName [ complexNavPath ]
+
+complexNavPath = "/" propertyPath 
+               / boundOperation
+               / querySegment
                  
 filterInPath = '/$filter' OPEN boolCommonExpr CLOSE
 
@@ -181,7 +182,7 @@ boundOperation = "/" ( boundActionCall
                      / boundEntityColFunctionCall    [ collectionnavigation ]
                      / boundEntityFunctionCall       [ singleNavigation ]
                      / boundComplexColFunctionCall   [ complexColPath ]
-                     / boundComplexFunctionCall      complexPath
+                     / boundComplexFunctionCall      [ complexPath ]
                      / boundPrimitiveColFunctionCall [ collectionPath ] 
                      / boundPrimitiveFunctionCall    [ primitivePath ] 
                      / boundFunctionCallNoParens     [ querySegment ]

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -167,7 +167,7 @@ value = '/$value'
 
 querySegment = '/$query'
 
-ordinalIndex = "/" 1*DIGIT
+ordinalIndex = "/" [ "-" ] 1*DIGIT
 
 ; boundOperation segments can only be composed if the type of the previous segment 
 ; matches the type of the first parameter of the action or function being called.

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -98,11 +98,11 @@ odataRelativeUri = '$batch'  [ "?" batchOptions ]
 ; 1. Resource Path
 ;------------------------------------------------------------------------------
 
-resourcePath = entitySetName                  [ collectionNavigation ] 
-             / singletonEntity                [ singleNavigation ]
+resourcePath = entitySetName                  collectionnavigation
+             / singletonEntity                singlenavigation
              / actionImportCall 
-             / entityColFunctionImportCall    [ collectionNavigation ] 
-             / entityFunctionImportCall       [ singleNavigation ] 
+             / entityColFunctionImportCall    collectionnavigation
+             / entityFunctionImportCall       singlenavigation 
              / complexColFunctionImportCall   [ complexColPath ] 
              / complexFunctionImportCall      [ complexPath ] 
              / primitiveColFunctionImportCall [ primitiveColPath ] 
@@ -112,8 +112,8 @@ resourcePath = entitySetName                  [ collectionNavigation ]
              / '$all'                         [ "/" optionallyQualifiedEntityTypeName ]
 
 collectionNavigation = [ "/" optionallyQualifiedEntityTypeName ] [ collectionNavPath ]
-collectionNavPath    = keyPredicate [ singleNavigation ]
-                     / filterInPath [ collectionNavigation ]
+collectionNavPath    = keyPredicate singlenavigation
+                     / filterInPath collectionNavigation
                      / each [ boundOperation ]
                      / boundOperation
                      / count
@@ -137,8 +137,8 @@ singleNavigation = [ "/" optionallyQualifiedEntityTypeName ]
                    / querySegment
                    ]
 
-propertyPath = entityColNavigationProperty [ collectionNavigation ]
-             / entityNavigationProperty    [ singleNavigation ]
+propertyPath = entityColNavigationProperty collectionNavigation
+             / entityNavigationProperty    singlenavigation
              / complexColProperty          [ complexColPath ]
              / complexProperty             [ complexPath ]
              / primitiveColProperty        [ primitiveColPath ]
@@ -173,8 +173,8 @@ ordinalIndex = "/" 1*DIGIT
 ; matches the type of the first parameter of the action or function being called.
 ; Note that the rule name reflects the return type of the function.
 boundOperation = "/" ( boundActionCall
-                     / boundEntityColFunctionCall    [ collectionNavigation ] 
-                     / boundEntityFunctionCall       [ singleNavigation ] 
+                     / boundEntityColFunctionCall    collectionnavigation
+                     / boundEntityFunctionCall       singlenavigation 
                      / boundComplexColFunctionCall   [ complexColPath ] 
                      / boundComplexFunctionCall      [ complexPath ]
                      / boundPrimitiveColFunctionCall [ primitiveColPath ] 

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -99,7 +99,7 @@ odataRelativeUri = '$batch'  [ "?" batchOptions ]
 ;------------------------------------------------------------------------------
 
 resourcePath = entitySetName                  [ collectionNavigation ] 
-             / singletonEntity                [ singleNavigation ]  
+             / singletonEntity                [ singleNavigation ]
              / actionImportCall 
              / entityColFunctionImportCall    [ collectionNavigation ] 
              / entityFunctionImportCall       [ singleNavigation ] 

--- a/abnf/odata-abnf-testcases.xml
+++ b/abnf/odata-abnf-testcases.xml
@@ -1114,7 +1114,7 @@
   <TestCase Name="4.10 Addressing a Member of an Ordered Complex Collection" Rule="odataRelativeUri">
     <Input>MainSupplier/Addresses/0</Input>
   </TestCase>
-  <TestCase Name="4.10 Addressing a Member of an Ordered Complex Collection with type-cast" Rule="odataRelativeUri" FailAt="49">
+  <TestCase Name="4.10 Addressing a Member of an Ordered Complex Collection with type-cast" Rule="odataRelativeUri">
     <Input>Suppliers(1)/Addresses/Model.AddressWithLocation/-1</Input>
   </TestCase>
   <TestCase Name="4.11 Inheritance - set of subtypes" Rule="odataRelativeUri">

--- a/abnf/odata-abnf-testcases.xml
+++ b/abnf/odata-abnf-testcases.xml
@@ -1115,7 +1115,7 @@
     <Input>MainSupplier/Addresses/0</Input>
   </TestCase>
   <TestCase Name="4.10 Addressing a Member of an Ordered Complex Collection with type-cast" Rule="odataRelativeUri" FailAt="49">
-    <Input>Suppliers(1)/Addresses/Model.AddressWithLocation/1</Input>
+    <Input>Suppliers(1)/Addresses/Model.AddressWithLocation/-1</Input>
   </TestCase>
   <TestCase Name="4.11 Inheritance - set of subtypes" Rule="odataRelativeUri">
     <Input>Products/Model.BestSellingProduct</Input>


### PR DESCRIPTION
- [x] negative index allowed with ordered collections
- [x] removed artificial restriction of ordinal index not allowed after a type-cast segment - this restriction cannot be deduced from https://issues.oasis-open.org/browse/ODATA-820, nor from the specification text
- [x] some optional segments can be empty