### PR TITLE
Rfc7405

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -41,8 +41,7 @@
 ;   literals in request and response payloads.
 ;
 ; Overview:
-;   This grammar uses the ABNF defined in RFC5234 with one extension: literals 
-;   enclosed in single quotes (e.g. '$metadata') are treated case-sensitive. 
+;   This grammar uses the ABNF defined in RFC5234 and RFC7405. 
 ;
 ;   The following rules assume that URIs have been percent-encoding normalized
 ;   as described in section 6.2.2.2 of RFC3986 

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -87,10 +87,10 @@ serviceRoot = ( "https" / "http" )                    ; Note: case-insensitive
               "/" *( segment-nz "/" )
 
 ; Note: dollar-prefixed path segments are case-sensitive!
-odataRelativeUri = '$batch'  [ "?" batchOptions ]
-                 / '$entity' "?" entityOptions  
-                 / '$entity' "/" optionallyQualifiedEntityTypeName "?" entityCastOptions  
-                 / '$metadata' [ "?" metadataOptions ] [ context ]
+odataRelativeUri = %s"$batch"  [ "?" batchOptions ]
+                 / %s"$entity" "?" entityOptions  
+                 / %s"$entity" "/" optionallyQualifiedEntityTypeName "?" entityCastOptions  
+                 / %s"$metadata" [ "?" metadataOptions ] [ context ]
                  / resourcePath [ "?" queryOptions ]
 
 
@@ -109,7 +109,7 @@ resourcePath = entitySetName                  [ collectionNavigation ]
              / primitiveFunctionImportCall    [ primitivePath ] 
              / functionImportCallNoParens     [ querySegment ]
              / crossjoin                      [ querySegment ]
-             / '$all'                         [ "/" optionallyQualifiedEntityTypeName ]
+             / %s"$all"                         [ "/" optionallyQualifiedEntityTypeName ]
 
 collectionNavigation = collectionNavPath
                      / "/" optionallyQualifiedEntityTypeName [ collectionNavPath ]
@@ -162,14 +162,14 @@ complexNavPath = "/" propertyPath
                / boundOperation
                / querySegment
                  
-filterInPath = '/$filter' OPEN boolCommonExpr CLOSE
+filterInPath = %s"/$filter" OPEN boolCommonExpr CLOSE
 
-each  = '/$each'
-count = '/$count'
-ref   = '/$ref'
-value = '/$value'
+each  = %s"/$each"
+count = %s"/$count"
+ref   = %s"/$ref"
+value = %s"/$value"
 
-querySegment = '/$query'
+querySegment = %s"/$query"
 
 ordinalIndex = "/" [ "-" ] 1*DIGIT
 
@@ -229,7 +229,7 @@ functionParameter  = parameterName EQ ( parameterAlias / primitiveLiteral )
 parameterName      = odataIdentifier
 parameterAlias     = AT odataIdentifier 
 
-crossjoin = '$crossjoin' OPEN
+crossjoin = %s"$crossjoin" OPEN
             entitySetName *( COMMA entitySetName )
             CLOSE
 
@@ -345,11 +345,11 @@ searchExpr = ( searchParenExpr
 searchParenExpr = OPEN BWS searchExpr BWS CLOSE
 
 ; NOT is a unary operator if followed by a search expression
-searchNegateExpr = 'NOT' RWS searchExpr
+searchNegateExpr = %s"NOT" RWS searchExpr
 
 ; AND and OR are binary operators if they appear between search expressions
-searchOrExpr  = RWS 'OR'  RWS searchExpr
-searchAndExpr = RWS [ 'AND' RWS ] searchExpr
+searchOrExpr  = RWS %s"OR"  RWS searchExpr
+searchAndExpr = RWS [ %s"AND" RWS ] searchExpr
 
 searchPhrase = quotation-mark 1*( qchar-no-AMP-DQUOTE / SP ) quotation-mark
 
@@ -424,15 +424,15 @@ primitiveColAnnotationInQuery = annotationInQuery ; primitive collection-valued 
 ;------------------------------------------------------------------------------
 
 context         = "#" contextFragment
-contextFragment = 'Collection($ref)'
-                / '$ref'
-                / 'Collection(Edm.EntityType)'
-                / 'Collection(Edm.ComplexType)'
+contextFragment = %s"Collection($ref)"
+                / %s"$ref"
+                / %s"Collection(Edm.EntityType)"
+                / %s"Collection(Edm.ComplexType)"
                 / singletonEntity [ navigation *( containmentNavigation ) [ "/" qualifiedEntityTypeName ] ] [ selectList ]
                 / qualifiedTypeName [ selectList ]
-                / entitySet ( '/$deletedEntity' / '/$link' / '/$deletedLink' )
+                / entitySet ( %s"/$deletedEntity" / %s"/$link" / %s"/$deletedLink" )
                 / entitySet keyPredicate "/" contextPropertyPath [ selectList ]
-                / entitySet [ selectList ] [ '/$entity' / '/$delta' ]
+                / entitySet [ selectList ] [ %s"/$entity" / %s"/$delta" ]
 
 entitySet = entitySetName *( containmentNavigation ) [ "/" qualifiedEntityTypeName ]
             
@@ -502,7 +502,7 @@ commonExpr = ( primitiveLiteral
 
 boolCommonExpr = commonExpr ; resulting in a Boolean
 
-rootExpr = '$root/' ( entitySetName keyPredicate / singletonEntity ) [ singleNavigationExpr ]
+rootExpr = %s"$root/" ( entitySetName keyPredicate / singletonEntity ) [ singleNavigationExpr ]
 
 firstMemberExpr = memberExpr
                 / inscopeVariableExpr [ "/" memberExpr ]
@@ -537,8 +537,8 @@ annotationQualifier  = odataIdentifier
 inscopeVariableExpr  = implicitVariableExpr 
                      / parameterAlias
                      / lambdaVariableExpr ; only allowed inside a lambdaPredicateExpr
-implicitVariableExpr = '$it'              ; the current instance of the resource identified by the resource path
-                     / '$this'            ; the instance on which the query option is evaluated
+implicitVariableExpr = %s"$it"              ; the current instance of the resource identified by the resource path
+                     / %s"$this"            ; the instance on which the query option is evaluated
 lambdaVariableExpr   = odataIdentifier
 
 collectionNavigationExpr = [ "/" optionallyQualifiedEntityTypeName ]
@@ -549,7 +549,7 @@ collectionNavigationExpr = [ "/" optionallyQualifiedEntityTypeName ]
 
 singleNavigationExpr = "/" memberExpr
 
-filterExpr = '/$filter' OPEN boolCommonExpr CLOSE
+filterExpr = %s"/$filter" OPEN boolCommonExpr CLOSE
 
 complexColPathExpr = collectionPathExpr
                    / "/" optionallyQualifiedComplexTypeName [ collectionPathExpr ]
@@ -736,12 +736,12 @@ charInJSON   = qchar-unescaped
              / escape ( quotation-mark 
                       / escape
                       / ( "/" / "%2F" ) ; solidus         U+002F - literal form is allowed in the query part of a URL
-                      / 'b'             ; backspace       U+0008                
-                      / 'f'             ; form feed       U+000C
-                      / 'n'             ; line feed       U+000A
-                      / 'r'             ; carriage return U+000D
-                      / 't'             ; tab             U+0009
-                      / 'u' 4HEXDIG     ;                 U+XXXX
+                      / %s"b"             ; backspace       U+0008                
+                      / %s"f"             ; form feed       U+000C
+                      / %s"n"             ; line feed       U+000A
+                      / %s"r"             ; carriage return U+000D
+                      / %s"t"             ; tab             U+0009
+                      / %s"u" 4HEXDIG     ;                 U+XXXX
                       )
 
 qchar-JSON-special = SP / ":" / "{" / "}" / "[" / "]" ; some agents put these unencoded into the query part of a URL
@@ -754,12 +754,12 @@ escape = "\" / "%5C"     ; reverse solidus U+005C
 ;------------------------------------------------------------------------------
 
 qualifiedTypeName = singleQualifiedTypeName                  
-                  / 'Collection' OPEN singleQualifiedTypeName CLOSE
+                  / %s"Collection" OPEN singleQualifiedTypeName CLOSE
 
 optionallyQualifiedTypeName = singleQualifiedTypeName                  
-                            / 'Collection' OPEN singleQualifiedTypeName CLOSE
+                            / %s"Collection" OPEN singleQualifiedTypeName CLOSE
                             / singleTypeName
-                            / 'Collection' OPEN singleTypeName CLOSE
+                            / %s"Collection" OPEN singleTypeName CLOSE
 
 singleQualifiedTypeName = qualifiedEntityTypeName 
                         / qualifiedComplexTypeName
@@ -798,34 +798,34 @@ odataIdentifier             = identifierLeadingCharacter *127identifierCharacter
 identifierLeadingCharacter  = ALPHA / "_"         ; plus Unicode characters from the categories L or Nl
 identifierCharacter         = ALPHA / "_" / DIGIT ; plus Unicode characters from the categories L, Nl, Nd, Mn, Mc, Pc, or Cf
 
-primitiveTypeName = 'Edm.' ( 'Binary'
-                           / 'Boolean'
-                           / 'Byte'
-                           / 'Date' 
-                           / 'DateTimeOffset'
-                           / 'Decimal'
-                           / 'Double'
-                           / 'Duration' 
-                           / 'Guid' 
-                           / 'Int16'
-                           / 'Int32'
-                           / 'Int64'
-                           / 'SByte'
-                           / 'Single'
-                           / 'Stream'
-                           / 'String'
-                           / 'TimeOfDay'
+primitiveTypeName = %s"Edm." ( %s"Binary"
+                           / %s"Boolean"
+                           / %s"Byte"
+                           / %s"Date" 
+                           / %s"DateTimeOffset"
+                           / %s"Decimal"
+                           / %s"Double"
+                           / %s"Duration" 
+                           / %s"Guid" 
+                           / %s"Int16"
+                           / %s"Int32"
+                           / %s"Int64"
+                           / %s"SByte"
+                           / %s"Single"
+                           / %s"Stream"
+                           / %s"String"
+                           / %s"TimeOfDay"
                            / abstractSpatialTypeName [ concreteSpatialTypeName ] 
                            )
-abstractSpatialTypeName = 'Geography'
-                        / 'Geometry'
-concreteSpatialTypeName = 'Collection'
-                        / 'LineString'
-                        / 'MultiLineString'
-                        / 'MultiPoint'
-                        / 'MultiPolygon'
-                        / 'Point'
-                        / 'Polygon'
+abstractSpatialTypeName = %s"Geography"
+                        / %s"Geometry"
+concreteSpatialTypeName = %s"Collection"
+                        / %s"LineString"
+                        / %s"MultiLineString"
+                        / %s"MultiPoint"
+                        / %s"MultiPolygon"
+                        / %s"Point"
+                        / %s"Polygon"
 
 primitiveProperty       = primitiveKeyProperty / primitiveNonKeyProperty
 primitiveKeyProperty    = odataIdentifier
@@ -930,13 +930,13 @@ primitiveValue = booleanValue
                ; - any XML string for strings in Atom and CSDL documents
                ; - any JSON string for JSON documents 
 
-nullValue = 'null' 
+nullValue = %s"null" 
 
 ; base64url encoding according to http://tools.ietf.org/html/rfc4648#section-5                                             
 binary      = "binary" SQUOTE binaryValue SQUOTE
 binaryValue = *(4base64char) [ base64b16  / base64b8 ]
-base64b16   = 2base64char ( 'A' / 'E' / 'I' / 'M' / 'Q' / 'U' / 'Y' / 'c' / 'g' / 'k' / 'o' / 's' / 'w' / '0' / '4' / '8' )   [ "=" ]
-base64b8    = base64char ( 'A' / 'Q' / 'g' / 'w' ) [ "==" ]
+base64b16   = 2base64char ( %s"A" / %s"E" / %s"I" / %s"M" / %s"Q" / %s"U" / %s"Y" / %s"c" / %s"g" / %s"k" / %s"o" / %s"s" / %s"w" / %s"0" / %s"4" / %s"8" )   [ "=" ]
+base64b8    = base64char ( %s"A" / %s"Q" / %s"g" / %s"w" ) [ "==" ]
 base64char  = ALPHA / DIGIT / "-" / "_"
 
 booleanValue = "true" / "false"
@@ -944,7 +944,7 @@ booleanValue = "true" / "false"
 decimalValue = [ SIGN ] 1*DIGIT [ "." 1*DIGIT ] [ "e" [ SIGN ] 1*DIGIT ] / nanInfinity
 doubleValue  = decimalValue ; IEEE 754 binary64 floating-point number (15-17 decimal digits)
 singleValue  = decimalValue ; IEEE 754 binary32 floating-point number (6-9 decimal digits)
-nanInfinity  = 'NaN' / '-INF' / 'INF'
+nanInfinity  = %s"NaN" / %s"-INF" / %s"INF"
 
 guidValue = 8HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 12HEXDIG 
 
@@ -1064,7 +1064,7 @@ request-id = 1*unreserved
 odata-entityid   = "OData-EntityID"   ":" OWS IRI-in-header
 
 ; Note: the header value is a JSON object restricted to characters allowed in a header
-odata-error      = "OData-Error"      ":" OWS '{"code":' *( VCHAR / SP )
+odata-error      = "OData-Error"      ":" OWS "{" DQUOTE %s"code" DQUOTE ":" *( VCHAR / SP )
 
 odata-maxversion = "OData-MaxVersion" ":" OWS 1*DIGIT "." 1*DIGIT     
 odata-version    = "OData-Version"    ":" OWS "4.0" [ oneToNine ]
@@ -1104,7 +1104,7 @@ omitValuesPreference = "omit-values" EQ-h ( "nulls" / "defaults" )
 
 respondAsyncPreference = "respond-async"
 
-returnPreference = "return" EQ-h ( 'representation' / 'minimal' )
+returnPreference = "return" EQ-h ( %s"representation" / %s"minimal" )
 
 trackChangesPreference = [ "odata." ] "track-changes"
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -76,7 +76,7 @@ primitiveProperty =/ expressionAlias / customAggregate
 ; 2. System Query Option $apply
 ;------------------------------------------------------------------------------
 
-apply      = %s"$apply" EQ applyExpr
+apply      = ( "$apply" / "apply" ) EQ applyExpr
 applyExpr  = applyTrafo *( "/" applyTrafo )
 applyTrafo = aggregateTrafo
            / bottomcountTrafo
@@ -101,14 +101,14 @@ aggregateExpr   = commonExpr aggregateWith [ aggregateFrom ] asAlias
                 / pathPrefix primitiveProperty aggregateWith [ aggregateFrom ] asAlias
                 / pathPrefix customAggregate [ customFrom asAlias ]
                 / pathPrefix pathSegment OPEN aggregateExpr CLOSE 
-aggregateWith   = RWS %s"with" RWS aggregateMethod        
+aggregateWith   = RWS %s"with" RWS aggregateMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperty aggregateWith [ aggregateFrom ]
 customFrom      = RWS %s"from" RWS groupingProperty [ aggregateWith ] [ customFrom ]
-aggregateMethod = %s"sum" 
-                / %s"min" 
-                / %s"max" 
-                / %s"average" 
-                / %s"countdistinct" 
+aggregateMethod = %s"sum"
+                / %s"min"
+                / %s"max"
+                / %s"average"
+                / %s"countdistinct"
                 / namespace "." odataIdentifier
 
 asAlias         = RWS %s"as" RWS expressionAlias
@@ -117,15 +117,15 @@ expressionAlias = odataIdentifier
 customAggregate = odataIdentifier
                 
 groupingProperty = pathPrefix
-                   ( entityNavigationProperty [ "/" qualifiedEntityTypeName ] 
+                   ( entityNavigationProperty [ "/" qualifiedEntityTypeName ]
                    / primitiveProperty 
                    / complexProperty
                    )
-pathPrefix       = [ ( qualifiedEntityTypeName / qualifiedComplexTypeName ) "/" ] *( pathSegment "/" ) 
+pathPrefix       = [ ( qualifiedEntityTypeName / qualifiedComplexTypeName ) "/" ] *( pathSegment "/" )
 pathSegment      = ( complexProperty / complexColProperty ) [ "/" qualifiedComplexTypeName ]
-                 / navigationProperty [ "/" qualifiedEntityTypeName  ] 
+                 / navigationProperty [ "/" qualifiedEntityTypeName  ]
                    
-computeTrafo = %s"compute" OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE     
+computeTrafo = %s"compute" OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE
 computeExpr  = commonExpr asAlias             
                            
 bottomcountTrafo   = %s"bottomcount"   OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
@@ -134,9 +134,9 @@ bottomsumTrafo     = %s"bottomsum"     OPEN BWS commonExpr BWS COMMA BWS commonE
 
 concatTrafo = %s"concat" OPEN BWS applyExpr 1*( BWS COMMA BWS applyExpr ) BWS CLOSE
 
-expandTrafo = %s"expand" OPEN BWS expandNavPath BWS COMMA BWS 
+expandTrafo = %s"expand" OPEN BWS expandNavPath BWS COMMA BWS
               ( expandTrafo *( BWS COMMA BWS expandTrafo )
-              / filterTrafo *( BWS COMMA BWS expandTrafo ) 
+              / filterTrafo *( BWS COMMA BWS expandTrafo )
               ) BWS CLOSE
 expandNavPath = [ ( qualifiedEntityTypeName / qualifiedComplexTypeName ) "/" ] 
                 *( ( complexProperty / complexColProperty ) "/" [ qualifiedComplexTypeName "/" ] )
@@ -151,7 +151,7 @@ groupbyList    = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS C
 groupbyElement = groupingProperty / rollupSpec
 rollupSpec     = %s"rollup" OPEN BWS 
                   ( %s"$all" / groupingProperty )
-                  1*( BWS COMMA BWS groupingProperty ) 
+                  1*( BWS COMMA BWS groupingProperty )
                   BWS CLOSE
 
 identityTrafo = %s"identity"

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -77,7 +77,7 @@ primitiveProperty =/ expressionAlias / customAggregate
 ; 2. System Query Option $apply
 ;------------------------------------------------------------------------------
 
-apply      = '$apply' EQ applyExpr
+apply      = %s"$apply" EQ applyExpr
 applyExpr  = applyTrafo *( "/" applyTrafo )
 applyTrafo = aggregateTrafo
            / bottomcountTrafo
@@ -95,24 +95,24 @@ applyTrafo = aggregateTrafo
            / topsumTrafo
            / customFunction
            
-aggregateTrafo  = 'aggregate' OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
-aggregateItem   = '$count' asAlias 
+aggregateTrafo  = %s"aggregate" OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
+aggregateItem   = %s"$count" asAlias 
                 / aggregateExpr
 aggregateExpr   = commonExpr aggregateWith [ aggregateFrom ] asAlias
                 / pathPrefix primitiveProperty aggregateWith [ aggregateFrom ] asAlias
                 / pathPrefix customAggregate [ customFrom asAlias ]
                 / pathPrefix pathSegment OPEN aggregateExpr CLOSE 
-aggregateWith   = RWS 'with' RWS aggregateMethod        
-aggregateFrom   = RWS 'from' RWS groupingProperty aggregateWith [ aggregateFrom ]
-customFrom      = RWS 'from' RWS groupingProperty [ aggregateWith ] [ customFrom ]
-aggregateMethod = 'sum' 
-                / 'min' 
-                / 'max' 
-                / 'average' 
-                / 'countdistinct' 
+aggregateWith   = RWS %s"with" RWS aggregateMethod        
+aggregateFrom   = RWS %s"from" RWS groupingProperty aggregateWith [ aggregateFrom ]
+customFrom      = RWS %s"from" RWS groupingProperty [ aggregateWith ] [ customFrom ]
+aggregateMethod = %s"sum" 
+                / %s"min" 
+                / %s"max" 
+                / %s"average" 
+                / %s"countdistinct" 
                 / namespace "." odataIdentifier
 
-asAlias         = RWS 'as' RWS expressionAlias
+asAlias         = RWS %s"as" RWS expressionAlias
 expressionAlias = odataIdentifier
                 
 customAggregate = odataIdentifier
@@ -126,16 +126,16 @@ pathPrefix       = [ ( qualifiedEntityTypeName / qualifiedComplexTypeName ) "/" 
 pathSegment      = ( complexProperty / complexColProperty ) [ "/" qualifiedComplexTypeName ]
                  / navigationProperty [ "/" qualifiedEntityTypeName  ] 
                    
-computeTrafo = 'compute' OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE     
+computeTrafo = %s"compute" OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE     
 computeExpr  = commonExpr asAlias             
                            
-bottomcountTrafo   = 'bottomcount'   OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
-bottompercentTrafo = 'bottompercent' OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
-bottomsumTrafo     = 'bottomsum'     OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
+bottomcountTrafo   = %s"bottomcount"   OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
+bottompercentTrafo = %s"bottompercent" OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
+bottomsumTrafo     = %s"bottomsum"     OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
 
-concatTrafo = 'concat' OPEN BWS applyExpr 1*( BWS COMMA BWS applyExpr ) BWS CLOSE
+concatTrafo = %s"concat" OPEN BWS applyExpr 1*( BWS COMMA BWS applyExpr ) BWS CLOSE
 
-expandTrafo = 'expand' OPEN BWS expandNavPath BWS COMMA BWS 
+expandTrafo = %s"expand" OPEN BWS expandNavPath BWS COMMA BWS 
               ( expandTrafo *( BWS COMMA BWS expandTrafo )
               / filterTrafo *( BWS COMMA BWS expandTrafo ) 
               ) BWS CLOSE
@@ -143,23 +143,23 @@ expandNavPath = [ ( qualifiedEntityTypeName / qualifiedComplexTypeName ) "/" ]
                 *( ( complexProperty / complexColProperty ) "/" [ qualifiedComplexTypeName "/" ] )
                 navigationProperty [ "/" qualifiedEntityTypeName ]
 
-filterTrafo = 'filter' OPEN BWS boolCommonExpr BWS CLOSE
+filterTrafo = %s"filter" OPEN BWS boolCommonExpr BWS CLOSE
 
-searchTrafo = 'search' OPEN BWS searchExpr BWS CLOSE
+searchTrafo = %s"search" OPEN BWS searchExpr BWS CLOSE
 
-groupbyTrafo   = 'groupby' OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] BWS CLOSE
+groupbyTrafo   = %s"groupby" OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] BWS CLOSE
 groupbyList    = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS CLOSE
 groupbyElement = groupingProperty / rollupSpec
-rollupSpec     = 'rollup' OPEN BWS 
-                  ( '$all' / groupingProperty )
+rollupSpec     = %s"rollup" OPEN BWS 
+                  ( %s"$all" / groupingProperty )
                   1*( BWS COMMA BWS groupingProperty ) 
                   BWS CLOSE
 
-identityTrafo = 'identity'
+identityTrafo = %s"identity"
 
-topcountTrafo   = 'topcount'   OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
-toppercentTrafo = 'toppercent' OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
-topsumTrafo     = 'topsum'     OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
+topcountTrafo   = %s"topcount"   OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
+toppercentTrafo = %s"toppercent" OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
+topsumTrafo     = %s"topsum"     OPEN BWS commonExpr BWS COMMA BWS commonExpr BWS CLOSE
 
 customFunction = namespace "." ( entityColFunction / complexColFunction / primitiveColFunction ) functionExprParameters
 
@@ -168,7 +168,7 @@ customFunction = namespace "." ( entityColFunction / complexColFunction / primit
 ; 3. Extensions to $filter
 ;------------------------------------------------------------------------------
 
-isdefinedExpr = 'isdefined' OPEN BWS ( firstMemberExpr ) BWS CLOSE
+isdefinedExpr = %s"isdefined" OPEN BWS ( firstMemberExpr ) BWS CLOSE
 
 
 ;------------------------------------------------------------------------------

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -48,8 +48,7 @@
 ;   of the base principles of OData.
 ;
 ; Overview:
-;   This grammar uses the ABNF defined in RFC5234 with one extension: literals 
-;   enclosed in single quotes (e.g. '$metadata') are treated case-sensitive. 
+;   This grammar uses the ABNF defined in RFC5234 and RFC7405. 
 ;
 ;   It extends the OData ABNF Construction Rules Version 4.0
 ;

--- a/abnf/odata-temporal-abnf.txt
+++ b/abnf/odata-temporal-abnf.txt
@@ -76,15 +76,15 @@ temporalOption = at-option
 ; 2. Temporal System Query Options
 ;------------------------------------------------------------------------------
 
-at-option  = '$at'         EQ temporalExpr
-from       = '$from'       EQ temporalExpr
-to         = '$to'         EQ temporalExpr
-systemat   = '$systemat'   EQ temporalExpr
-systemfrom = '$systemfrom' EQ temporalExpr
-systemto   = '$systemto'   EQ temporalExpr
+at-option  = %s"$at"         EQ temporalExpr
+from       = %s"$from"       EQ temporalExpr
+to         = %s"$to"         EQ temporalExpr
+systemat   = %s"$systemat"   EQ temporalExpr
+systemfrom = %s"$systemfrom" EQ temporalExpr
+systemto   = %s"$systemto"   EQ temporalExpr
 
-temporalExpr = 'min' 
-             / 'max' 
+temporalExpr = %s"min" 
+             / %s"max" 
              / dateTimeOffsetValue 
              / dateValue
 

--- a/abnf/odata-temporal-abnf.txt
+++ b/abnf/odata-temporal-abnf.txt
@@ -75,15 +75,15 @@ temporalOption = at-option
 ; 2. Temporal System Query Options
 ;------------------------------------------------------------------------------
 
-at-option  = %s"$at"         EQ temporalExpr
-from       = %s"$from"       EQ temporalExpr
-to         = %s"$to"         EQ temporalExpr
-systemat   = %s"$systemat"   EQ temporalExpr
-systemfrom = %s"$systemfrom" EQ temporalExpr
-systemto   = %s"$systemto"   EQ temporalExpr
+at-option  = "$at"         EQ temporalExpr
+from       = "$from"       EQ temporalExpr
+to         = "$to"         EQ temporalExpr
+systemat   = "$systemat"   EQ temporalExpr
+systemfrom = "$systemfrom" EQ temporalExpr
+systemto   = "$systemto"   EQ temporalExpr
 
-temporalExpr = %s"min" 
-             / %s"max" 
+temporalExpr = "min" 
+             / "max" 
              / dateTimeOffsetValue 
              / dateValue
 

--- a/abnf/odata-temporal-abnf.txt
+++ b/abnf/odata-temporal-abnf.txt
@@ -45,8 +45,7 @@
 ;   using the Open Data Protocol (OData).
 ;
 ; Overview:
-;   This grammar uses the ABNF defined in RFC5234 with one extension: literals 
-;   enclosed in single quotes (e.g. '$metadata') are treated case-sensitive. 
+;   This grammar uses the ABNF defined in RFC5234 and RFC7405. 
 ;
 ;   It extends the OData ABNF Construction Rules Version 4.0
 ;

--- a/tools/PowerShell/check-abnf.ps1
+++ b/tools/PowerShell/check-abnf.ps1
@@ -10,8 +10,6 @@
     Prerequisites 
     - Java SDK         http://jdk.java.net
     - Git              https://git-scm.com/download/win 
-    - Java APG         https://github.com/ralfhandl/apg-java
-    - ABNF test tool   https://github.com/SAP/abnf-test-tool
 #>
 
 param (
@@ -77,9 +75,9 @@ function CompileAndCheck {
     if ( !(Test-Path "grammar") ) { mkdir "grammar" >$null }
 
     if ( !(Test-Path "grammar/GrammarUnderTest.java") -or
-         (get-item "grammar/GrammarUnderTest.java").LastWriteTime -lt (get-item "../../abnf/odata-abnf-construction-rules.txt").LastWriteTime -or 
-         (get-item "grammar/GrammarUnderTest.java").LastWriteTime -lt (get-item "../../abnf/odata-aggregation-abnf.txt").LastWriteTime -or
-         (get-item "grammar/GrammarUnderTest.java").LastWriteTime -lt (get-item "../../abnf/odata-temporal-abnf.txt").LastWriteTime ) {
+        (get-item "grammar/GrammarUnderTest.java").LastWriteTime -lt (get-item "../../abnf/odata-abnf-construction-rules.txt").LastWriteTime -or 
+        (get-item "grammar/GrammarUnderTest.java").LastWriteTime -lt (get-item "../../abnf/odata-aggregation-abnf.txt").LastWriteTime -or
+        (get-item "grammar/GrammarUnderTest.java").LastWriteTime -lt (get-item "../../abnf/odata-temporal-abnf.txt").LastWriteTime ) {
 
         Write-Output "Compiling ABNF..."
 
@@ -94,7 +92,7 @@ function CompileAndCheck {
 
     # compile parser
     if ( !(Test-Path "grammar/GrammarUnderTest.class") -or
-         (get-item "grammar/GrammarUnderTest.java").LastWriteTime -gt (get-item "grammar/GrammarUnderTest.class").LastWriteTime ) {
+        (get-item "grammar/GrammarUnderTest.java").LastWriteTime -gt (get-item "grammar/GrammarUnderTest.class").LastWriteTime ) {
 
         javac.exe -cp ../../../apg-java/build/apg.jar grammar/GrammarUnderTest.java
         if (!$?) { return }
@@ -110,15 +108,14 @@ if ($watch) {
     $PathToMonitor = Resolve-Path "$pwd\..\..\abnf"
 
     $FileSystemWatcher = New-Object System.IO.FileSystemWatcher
-    $FileSystemWatcher.Path  = $PathToMonitor
+    $FileSystemWatcher.Path = $PathToMonitor
     $FileSystemWatcher.IncludeSubdirectories = $true
     
     Write-Host "Monitoring content of $PathToMonitor"
     
     while ($true) {
         $Change = $FileSystemWatcher.WaitForChanged('All', 1000)
-        if ($Change.TimedOut -eq $false)
-        {
+        if ($Change.TimedOut -eq $false) {
             CompileAndCheck
         }
     }


### PR DESCRIPTION
Using RFC7405 compliant notation for denoting case-sensitive string literals, ie: %s"aBc"