### PR TITLE
verifying a bug in the generated parser

### DIFF
--- a/abnf/odata-abnf-testcases.xml
+++ b/abnf/odata-abnf-testcases.xml
@@ -364,6 +364,10 @@
     <Match>MonetaryAmount</Match>
   </Constraint>
 
+  <TestCase Name="Verifying the generated parser" Rule="namespace">
+    <Input>This.Should.Not.Fail</Input>
+  </TestCase>
+  
   <TestCase Name="Just to test the dummy start rule" Rule="dummyStartRule">
     <Input>http://services.odata.org/</Input>
   </TestCase>


### PR DESCRIPTION
I think I may have discovered a bug in the generated parser. I've added a test case that should not fail according to the grammar, but it does.

The official OData-ABNF grammar does indeed include ambiguities that could possibly be resolved in order to allow for generating parsers without the need for "Constraint"s but there additionally seems to be a bug in the generated parser.