### PR TITLE
Remove dummy start rule

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -75,9 +75,6 @@
 ;   C. ABNF core definitions [RFC5234]
 ;
 ;------------------------------------------------------------------------------
-dummyStartRule = odataUri / header / primitiveValue ; just to please the test parser
-;------------------------------------------------------------------------------
-
 
 odataUri = serviceRoot [ odataRelativeUri ]  
 

--- a/abnf/odata-abnf-testcases.yaml
+++ b/abnf/odata-abnf-testcases.yaml
@@ -254,10 +254,6 @@ Constraints:
     - Thumbnail
 
 TestCases:
-  - Name: Just to test the dummy start rule
-    Rule: dummyStartRule
-    Input: http://services.odata.org/
-
   - Name: URI with IPv4 address, path and trailing slash
     Rule: odataUri
     Input: http://127.0.0.1:8080/MyService/


### PR DESCRIPTION
Was only necessary with the old parser generator