### PR TITLE
Fix incorrect prefix for Geo Collections

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -995,7 +995,7 @@ enumMemberValue = int64Value
 
 geographyCollection   = geographyPrefix SQUOTE fullCollectionLiteral SQUOTE
 fullCollectionLiteral = sridLiteral collectionLiteral
-collectionLiteral     = "Collection(" geoLiteral *( COMMA geoLiteral ) CLOSE
+collectionLiteral     = "GeometryCollection(" geoLiteral *( COMMA geoLiteral ) CLOSE
 geoLiteral            = collectionLiteral
                       / lineStringLiteral
                       / multiPointLiteral

--- a/abnf/odata-abnf-testcases.yaml
+++ b/abnf/odata-abnf-testcases.yaml
@@ -2953,7 +2953,7 @@ TestCases:
 
   - Name: GeographyCollection
     Rule: geographyCollection
-    Input: geography'SRID=0;Collection(LineString(142.1 64.1,3.14 2.78))'
+    Input: geography'SRID=0;GeometryCollection(LineString(142.1 64.1,3.14 2.78))'
 
   - Name: GeographyLineString
     Rule: geographyLineString
@@ -2995,7 +2995,7 @@ TestCases:
 
   - Name: GeometryCollection
     Rule: geometryCollection
-    Input: geometry'SRID=0;Collection(LineString(142.1 64.1,3.14 2.78))'
+    Input: geometry'SRID=0;GeometryCollection(LineString(142.1 64.1,3.14 2.78))'
 
   - Name: GeometryLineString
     Rule: geometryLineString


### PR DESCRIPTION
Fixes #56 

Prefix for geo collections is "GeometryCollection", not "Collection", according to all sources cited on [Wikipedia](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry), and also according to [OData V3](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-odata/61934eae-311a-4af4-b8f8-82c112248651)