### PR TITLE
ODATA-1507 - Add test case for Filter Path Segment followed by key predicate

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -547,8 +547,9 @@ lambdaVariableExpr   = odataIdentifier
 collectionNavigationExpr = collectionNavNoCastExpr
                          / "/" optionallyQualifiedEntityTypeName collectionNavNoCastExpr
 
-collectionNavNoCastExpr = collectionPathExpr
-                        / keyPredicate [ singleNavigationExpr ]               
+collectionNavNoCastExpr = keyPredicate [ singleNavigationExpr ]
+                        / filterExpr [ collectionNavigationExpr ]
+                        / collectionPathExpr
 
 singleNavigationExpr = "/" memberExpr
 

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -548,8 +548,7 @@ collectionNavigationExpr = collectionNavNoCastExpr
                          / "/" optionallyQualifiedEntityTypeName collectionNavNoCastExpr
 
 collectionNavNoCastExpr = collectionPathExpr
-                        / keyPredicate [ singleNavigationExpr ] 
-                      ;  / filterExpr [ collectionNavigationExpr ]                     
+                        / keyPredicate [ singleNavigationExpr ]               
 
 singleNavigationExpr = "/" memberExpr
 

--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -549,7 +549,7 @@ collectionNavigationExpr = collectionNavNoCastExpr
 
 collectionNavNoCastExpr = collectionPathExpr
                         / keyPredicate [ singleNavigationExpr ] 
-                        / filterExpr [ collectionNavigationExpr ]                     
+                      ;  / filterExpr [ collectionNavigationExpr ]                     
 
 singleNavigationExpr = "/" memberExpr
 

--- a/abnf/odata-abnf-testcases.yaml
+++ b/abnf/odata-abnf-testcases.yaml
@@ -1420,6 +1420,10 @@ TestCases:
     Rule: odataRelativeUri
     Input: Products/$filter(@foo)/Special.Cluster?@foo=Age gt 3
 
+  - Name: 4.12 Filter Path Segment followed by key predicate
+    Rule: propertyPathExpr
+    Input: Products/$filter(Age gt 3)(ID='Sugar')
+
   - Name: 4.12 Filter expression in query
     Rule: odataRelativeUri
     Input: Categories?$filter=Products/$filter(Age gt 3)/$count lt 10


### PR DESCRIPTION
`filterExpr` can already be reached via `collectionPathExpr`, so this rule alternative is redundant