### PR TITLE
$root expressions with entity set

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -499,6 +499,7 @@ commonExpr = ( primitiveLiteral
 boolCommonExpr = commonExpr ; resulting in a Boolean
 
 rootExpr = %s"$root/" ( ( entitySetName keyPredicate / singletonEntity ) [ singleNavigationExpr ]
+                      / entitySetName                  [ collectionNavigation ]
                       / entityColFunctionImportCall    [ collectionNavigation ]
                       / entityFunctionImportCall       [ singleNavigation ]
                       / complexColFunctionImportCall   [ complexColPath ]


### PR DESCRIPTION
The test
```
- Name: collection path expression with $root
  Rule: commonExpr
  Input: $root/SalesOrganizations
```
passed, but only because our test cases do not distinguish between `entitySetName` and `singletonEntity`. If I add a constraint
```
Constraints:
  singletonEntity: []
```
the test fails with error
```
collection path expression with $root fails at 24: $root/SalesOrganizations
```