### PR TITLE
DO NOT MERGE: Redundant constraints

### DIFF
--- a/abnf/odata-grouping-testcases.yaml
+++ b/abnf/odata-grouping-testcases.yaml
@@ -1,0 +1,15 @@
+Constraints:
+  entityNavigationProperty:
+    - Product
+  entityTypeName:
+    - DigitalProduct
+  namespacePart:
+    - self
+  primitiveNonKeyProperty:
+    - DigitalProduct
+  odataIdentifier: []
+
+TestCases:
+  - Name: ambiguity type cast/property name
+    Rule: groupingProperty
+    Input: Product/self.DigitalProduct/DigitalProduct


### PR DESCRIPTION
`npm run test` causes a test case to fail. It passes if you change
```
Constraints:
  odataIdentifier:
    - Product
    - DigitalProduct
    - self
```
But since these phrases are already allowed for other rules, it should not be necessary to redundantly allow them as `odataIdentifier`s.
