### PR TITLE
Fix: allow empty query options

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -87,7 +87,7 @@ odataRelativeUri = %s"$batch"  [ "?" batchOptions ]
                  / %s"$entity" "?" entityOptions  
                  / %s"$entity" "/" optionallyQualifiedEntityTypeName "?" entityCastOptions  
                  / %s"$metadata" [ "?" metadataOptions ] [ context ]
-                 / resourcePath [ "?" queryOptions ]
+                 / resourcePath [ "?" [ queryOptions ] ]
 
 
 ;------------------------------------------------------------------------------

--- a/abnf/odata-abnf-testcases.yaml
+++ b/abnf/odata-abnf-testcases.yaml
@@ -767,6 +767,10 @@ TestCases:
     FailAt: 22
     Input: Categories('Smartphone/Tablet')
 
+  - Name: 2 URL Components - empty query options
+    Rule: odataRelativeUri
+    Input: Customers?
+
   - Name: 4.1 - Metadata URL
     Rule: odataUri
     Input: http://services.odata.org/OData/OData.svc/$metadata


### PR DESCRIPTION
Some client tools send a trailing `?` after a resource path without adding any query options, which is valid according to [RFC3986, section 3.4](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4).

Some server implementations don't accept this because so far it is not explicitly allowed by our ABNF.