### PR TITLE
`from` multiple dimensions

### DIFF
--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -215,7 +215,7 @@ descendantsTrafo = %s"descendants" OPEN
                  CLOSE
 
 traverseTrafo   = %s"traverse" OPEN 
-                  BWS recHierReference BWS 
+                  BWS recHierQualifier BWS 
                   COMMA BWS ( %s"preorder" / %s"postorder" ) BWS 
                   CLOSE 
 
@@ -232,11 +232,12 @@ searchTrafo     = %s"search" OPEN BWS searchExpr BWS CLOSE
 
 groupbyTrafo    = %s"groupby" OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] BWS CLOSE
 groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS CLOSE
-groupbyElement  = groupingProperty / rollup / rollupDesc
+groupbyElement  = groupingProperty / rollup / rollupAll
 
-rollup            = ( %s"rollupall" / %s"rollup" )
-                    OPEN BWS ( groupingProperty 1*( BWS COMMA BWS groupingProperty ) ) BWS CLOSE
-rollupDesc        = %s"rollupdescendants" OPEN BWS recHierReference BWS CLOSE
+rollup            = %s"rollup"    OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
+rollupAll         = %s"rollupall" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
+rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
+rollupNamedHier   = recHierQualifier
 
 identityTrafo   = %s"identity"
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -208,7 +208,7 @@ descendantsTrafo = %s"descendants" OPEN
                  CLOSE
 
 traverseTrafo   = %s"traverse" OPEN 
-                  BWS recHierQualifier BWS 
+                  BWS recHierReference BWS 
                   COMMA BWS ( %s"preorder" / %s"postorder" ) BWS 
                   CLOSE 
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -117,7 +117,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperty aggregateWith [ aggregateFrom ]
-customFrom      = 1*( RWS %s"from" RWS groupingProperty ) aggregateWith
+customFrom      = 1*( RWS %s"from" RWS groupingProperty ) aggregateWith [ aggregateFrom ]
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -116,8 +116,8 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
-aggregateFrom   = RWS %s"from" RWS groupingProperty aggregateWith [ aggregateFrom ]
-customFrom      = 1*( RWS %s"from" RWS groupingProperty ) aggregateWith [ aggregateFrom ]
+aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
+customFrom      = 1*( RWS %s"from" RWS groupingProperties ) aggregateWith [ aggregateFrom ]
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"
@@ -170,6 +170,8 @@ aggregatableExpr   = aggregatableArith
 aggrPathPrimitive  = optionalLeadingTypeCast aggrPrimPath
 aggrPathPrefix     = optionalLeadingTypeCast aggrPropPath
 groupingProperty   = optionalLeadingTypeCast ( snglPrimPath / snglPropPath )
+groupingProperties = groupingProperty
+                   / OPEN BWS groupingProperty *( BWS COMMA BWS groupingProperty ) BWS CLOSE
 
 computeTrafo    = %s"compute" OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE
 computeExpr     = commonExpr asAlias             

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -227,12 +227,11 @@ searchTrafo     = %s"search" OPEN BWS searchExpr BWS CLOSE
 
 groupbyTrafo    = %s"groupby" OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] BWS CLOSE
 groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS CLOSE
-groupbyElement  = groupingProperty / rollup / rollupAll
+groupbyElement  = groupingProperty / rollup / rollupDesc
 
-rollup            = %s"rollup"    OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupAll         = %s"rollupall" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
-rollupNamedHier   = OPEN BWS recHierReference BWS CLOSE
+rollup            = ( %s"rollup" / %s"rollupall" )
+                    OPEN BWS ( groupingProperty 1*( BWS COMMA BWS groupingProperty ) ) BWS CLOSE
+rollupDesc        = %s"rollupdescendants" OPEN BWS recHierReference BWS CLOSE
 
 identityTrafo   = %s"identity"
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -117,7 +117,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
-customFrom      = 1*( RWS %s"from" RWS groupingProperties ) [ aggregateWith ] [ customFrom ]
+customFrom      = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -117,7 +117,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperty aggregateWith [ aggregateFrom ]
-customFrom      = RWS %s"from" RWS groupingProperty [ aggregateWith ] [ customFrom ]
+customFrom      = 1*( RWS %s"from" RWS groupingProperty ) aggregateWith
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -229,7 +229,7 @@ groupbyTrafo    = %s"groupby" OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] B
 groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS CLOSE
 groupbyElement  = groupingProperty / rollup / rollupDesc
 
-rollup            = ( %s"rollup" / %s"rollupall" )
+rollup            = ( %s"rollupall" / %s"rollup" )
                     OPEN BWS ( groupingProperty 1*( BWS COMMA BWS groupingProperty ) ) BWS CLOSE
 rollupDesc        = %s"rollupdescendants" OPEN BWS recHierReference BWS CLOSE
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -170,8 +170,7 @@ aggregatableExpr   = aggregatableArith
 aggrPathPrimitive  = optionalLeadingTypeCast aggrPrimPath
 aggrPathPrefix     = optionalLeadingTypeCast aggrPropPath
 groupingProperty   = optionalLeadingTypeCast ( snglPrimPath / snglPropPath )
-groupingProperties = groupingProperty
-                   / OPEN BWS groupingProperty *( BWS COMMA BWS groupingProperty ) BWS CLOSE
+groupingProperties = groupingProperty *( BWS COMMA BWS groupingProperty )
 
 computeTrafo    = %s"compute" OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE
 computeExpr     = commonExpr asAlias             

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -230,7 +230,7 @@ groupbyElement  = groupingProperty / rollup / rollupAll
 rollup            = %s"rollup"    OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupAll         = %s"rollupall" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
-rollupNamedHier   = recHierQualifier
+rollupNamedHier   = OPEN BWS recHierReference BWS CLOSE
 
 identityTrafo   = %s"identity"
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -117,7 +117,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
-customFrom      = 1*( RWS %s"from" RWS groupingProperties ) aggregateWith [ aggregateFrom ]
+customFrom      = 1*( RWS %s"from" RWS groupingProperties ) [ aggregateWith ] [ customFrom ]
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -401,7 +401,11 @@ TestCases:
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time from Product/Name with average as DailyAverage)
 
-  - Name: aggregate - custom aggregate and multiple from
+  - Name: aggregate - custom aggregate and from multiple
+    Rule: queryOptions
+    Input: $apply=aggregate(Forecast from (Time,Product/Name) with average as DailyAverage)
+
+  - Name: aggregate - custom aggregate and multiple from with
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average from Product/Name with max as DailyAverage)
 

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -687,31 +687,59 @@ TestCases:
 
   - Name: hierarchy functions - isroot
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.isroot(Hierarchy='SalesOrgHierarchy')
+    Input: SalesOrganizations?$filter=Aggregation.isroot(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID)
 
   - Name: hierarchy functions - isdescendant
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.isdescendant(Hierarchy='SalesOrgHierarchy',Node='EMEA')
+    Input: SalesOrganizations?$filter=Aggregation.isdescendant(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID,
+      Ancestor='EMEA')
 
   - Name: hierarchy functions - isdescendant
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.isdescendant(Hierarchy='SalesOrgHierarchy',Node='EMEA',MaxDistance=1)
+    Input: SalesOrganizations?$filter=Aggregation.isdescendant(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID,
+      Ancestor='EMEA',
+      MaxDistance=1)
 
   - Name: hierarchy functions - isancestor
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.isancestor(Hierarchy='SalesOrgHierarchy',Node='EMEA')
+    Input: SalesOrganizations?$filter=Aggregation.isancestor(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID,
+      Descendant='EMEA')
 
   - Name: hierarchy functions - isancestor
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.isancestor(Hierarchy='SalesOrgHierarchy',Node='EMEA',MaxDistance=1)
+    Input: SalesOrganizations?$filter=Aggregation.isancestor(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID,
+      Descendant='EMEA',
+      MaxDistance=1)
 
   - Name: hierarchy functions - issibling
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.issibling(Hierarchy='SalesOrgHierarchy',Node='EMEA')
+    Input: SalesOrganizations?$filter=Aggregation.issibling(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID,
+      Other='EMEA')
 
   - Name: hierarchy functions - isleaf
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=$it/Aggregation.isleaf(Hierarchy='SalesOrgHierarchy')
+    Input: SalesOrganizations?$filter=Aggregation.isleaf(
+      HierarchyNodes=$root/SalesOrganizations,
+      HierarchyQualifier='SalesOrgHierarchy',
+      Node=ID)
 
   - Name: hierarchy transformations - ancestors with forbidden node property path
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -384,6 +384,15 @@ TestCases:
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average as DailyAverage)
 
+  - Name: aggregate - custom aggregate and multiple from
+    Rule: queryOptions
+    Input: $apply=aggregate(Forecast from Time from Product/Name with average as DailyAverage)
+
+  - Name: aggregate - custom aggregate and from without with
+    Rule: queryOptions
+    FailAt: 36
+    Input: $apply=aggregate(Forecast from Time as Stuff)
+
   - Name: aggregate - path with key segment
     Rule: queryOptions
     FailAt: 34

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -382,7 +382,12 @@ TestCases:
     FailAt: 55
     Input: $apply=aggregate(Amount with sum from Time with average)
 
-  - Name: aggregate - property from requires with
+  - Name: aggregate - property from requires with 1
+    Rule: queryOptions
+    FailAt: 47
+    Input: $apply=aggregate(Amount with average from Time as DailyAverage)
+
+  - Name: aggregate - property from requires with 2
     Rule: queryOptions
     FailAt: 24
     Input: $apply=aggregate(Amount from Time with average as DailyAverage)

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -481,7 +481,7 @@ TestCases:
 
   - Name: aggregate - groupby rollup recursive hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rollup(($root/SalesOrganizations,SalesOrgHierarchy,ID))),aggregate($count as
+    Input: $apply=groupby((rollupdescendants($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
       SalesOrgCount))
 
   - Name: aggregate - filter
@@ -1040,7 +1040,8 @@ TestCases:
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rollup(($root/SalesOrganizations,SalesOrgHierarchy,ID))),aggregate(Sales/$count as PaperSalesCount))
+      'Paper'))/groupby((rollupdescendants($root/SalesOrganizations,SalesOrgHierarchy,ID)),
+      aggregate(Sales/$count as PaperSalesCount))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -481,7 +481,7 @@ TestCases:
 
   - Name: aggregate - groupby rollup recursive hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rollup(SalesOrgHierarchy)),aggregate($count as
+    Input: $apply=groupby((rollup(($root/SalesOrganizations,SalesOrgHierarchy,ID))),aggregate($count as
       SalesOrgCount))
 
   - Name: aggregate - filter
@@ -1002,7 +1002,7 @@ TestCases:
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rollup(SalesOrgHierarchy)),aggregate(Sales/$count as PaperSalesCount))
+      'Paper'))/groupby((rollup(($root/SalesOrganizations,SalesOrgHierarchy,ID))),aggregate(Sales/$count as PaperSalesCount))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -526,7 +526,7 @@ TestCases:
 
   - Name: aggregate - groupby rollup recursive hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rollupdescendants($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
+    Input: $apply=groupby((rollup(SalesOrgHierarchy)),aggregate($count as
       SalesOrgCount))
 
   - Name: aggregate - filter
@@ -740,59 +740,31 @@ TestCases:
 
   - Name: hierarchy functions - isroot
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.isroot(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID)
+    Input: SalesOrganizations?$filter=$it/Aggregation.isroot(Hierarchy='SalesOrgHierarchy')
 
   - Name: hierarchy functions - isdescendant
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.isdescendant(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID,
-      Ancestor='EMEA')
+    Input: SalesOrganizations?$filter=$it/Aggregation.isdescendant(Hierarchy='SalesOrgHierarchy',Node='EMEA')
 
   - Name: hierarchy functions - isdescendant
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.isdescendant(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID,
-      Ancestor='EMEA',
-      MaxDistance=1)
+    Input: SalesOrganizations?$filter=$it/Aggregation.isdescendant(Hierarchy='SalesOrgHierarchy',Node='EMEA',MaxDistance=1)
 
   - Name: hierarchy functions - isancestor
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.isancestor(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID,
-      Descendant='EMEA')
+    Input: SalesOrganizations?$filter=$it/Aggregation.isancestor(Hierarchy='SalesOrgHierarchy',Node='EMEA')
 
   - Name: hierarchy functions - isancestor
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.isancestor(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID,
-      Descendant='EMEA',
-      MaxDistance=1)
+    Input: SalesOrganizations?$filter=$it/Aggregation.isancestor(Hierarchy='SalesOrgHierarchy',Node='EMEA',MaxDistance=1)
 
   - Name: hierarchy functions - issibling
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.issibling(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID,
-      Other='EMEA')
+    Input: SalesOrganizations?$filter=$it/Aggregation.issibling(Hierarchy='SalesOrgHierarchy',Node='EMEA')
 
   - Name: hierarchy functions - isleaf
     Rule: odataRelativeUri
-    Input: SalesOrganizations?$filter=Aggregation.isleaf(
-      HierarchyNodes=$root/SalesOrganizations,
-      HierarchyQualifier='SalesOrgHierarchy',
-      Node=ID)
+    Input: SalesOrganizations?$filter=$it/Aggregation.isleaf(Hierarchy='SalesOrgHierarchy')
 
   - Name: hierarchy transformations - ancestors with forbidden node property path
     Rule: queryOptions
@@ -839,7 +811,7 @@ TestCases:
 
   - Name: hierarchy transformations - traverse
     Rule: queryOptions
-    Input: $apply=traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
+    Input: $apply=traverse(SalesOrgHierarchy,preorder)
 
   - Name: distinct values - no aggregate
     Rule: odataRelativeUri
@@ -1084,13 +1056,12 @@ TestCases:
     Rule: queryOptions
     Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),keep
       start)/ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East')),keep
-      start)/traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
+      start)/traverse(SalesOrgHierarchy,preorder)
 
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rollupdescendants($root/SalesOrganizations,SalesOrgHierarchy,ID)),
-      aggregate(Sales/$count as PaperSalesCount))
+      'Paper'))/groupby((rollup(SalesOrgHierarchy)),aggregate(Sales/$count as PaperSalesCount))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -361,13 +361,13 @@ TestCases:
   - Name: aggregate - from twice
     Rule: queryOptions
     Input:
-      $apply=aggregate(Amount with sum from Time with average from (Product/Name)
+      $apply=aggregate(Amount with sum from Time with average from Product/Name
       with max as DailyAverage)
 
   - Name: aggregate - from twice in one step
     Rule: queryOptions
     Input:
-      $apply=aggregate(Amount with average from (Time,Product/Name)
+      $apply=aggregate(Amount with average from Time,Product/Name
       with max as DailyAverage)
 
   - Name: aggregate - from twice in one step wrong
@@ -408,7 +408,7 @@ TestCases:
 
   - Name: aggregate - custom aggregate and from multiple
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from (Time,Product/Name) with average as DailyAverage)
+    Input: $apply=aggregate(Forecast from Time,Product/Name with average as DailyAverage)
 
   - Name: aggregate - custom aggregate and multiple from with
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -364,6 +364,13 @@ TestCases:
       $apply=aggregate(Amount with sum from Time with average from Product/Name
       with max as DailyAverage)
 
+  - Name: aggregate - from twice in one step
+    Rule: queryOptions
+    FailAt: 47
+    Input:
+      $apply=aggregate(Amount with average from Time from Product/Name
+      with max as DailyAverage)
+
   - Name: aggregate - from requires as
     Rule: queryOptions
     FailAt: 55
@@ -387,6 +394,10 @@ TestCases:
   - Name: aggregate - custom aggregate and multiple from
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time from Product/Name with average as DailyAverage)
+
+  - Name: aggregate - custom aggregate and multiple from
+    Rule: queryOptions
+    Input: $apply=aggregate(Forecast from Time with average from Product/Name with max as DailyAverage)
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -361,10 +361,16 @@ TestCases:
   - Name: aggregate - from twice
     Rule: queryOptions
     Input:
-      $apply=aggregate(Amount with sum from Time with average from Product/Name
+      $apply=aggregate(Amount with sum from Time with average from (Product/Name)
       with max as DailyAverage)
 
   - Name: aggregate - from twice in one step
+    Rule: queryOptions
+    Input:
+      $apply=aggregate(Amount with average from (Time,Product/Name)
+      with max as DailyAverage)
+
+  - Name: aggregate - from twice in one step wrong
     Rule: queryOptions
     FailAt: 47
     Input:

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -409,9 +409,12 @@ TestCases:
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average from Product/Name with max as DailyAverage)
 
+  - Name: aggregate - custom aggregate, with, custom aggregate again
+    Rule: queryOptions
+    Input: $apply=aggregate(Forecast from Time with average from Product/Name as DailyAverage)
+
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    FailAt: 36
     Input: $apply=aggregate(Forecast from Time as Stuff)
 
   - Name: aggregate - path with key segment

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -752,7 +752,7 @@ TestCases:
 
   - Name: hierarchy transformations - traverse
     Rule: queryOptions
-    Input: $apply=traverse(SalesOrgHierarchy,preorder)
+    Input: $apply=traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
 
   - Name: distinct values - no aggregate
     Rule: odataRelativeUri
@@ -997,7 +997,7 @@ TestCases:
     Rule: queryOptions
     Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,Name eq 'US',keep
       start)/ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,contains(Name,'East'),keep
-      start)/traverse(SalesOrgHierarchy,preorder)
+      start)/traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
 
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions


### PR DESCRIPTION
`from` allows only one dimension per aggregation step. But multiple dimensions may be desired (for example, `ControllingArea,CostCenter`), because the number of steps influences the result of `average`, say.

## Suggested alternative definition
In the following $P_1,…,P_n$ are groupable properties, $M$ is an aggregation method and $C$ a custom aggregate. ... from ... denotes a sequence of `from` and `with` clauses ending in a `from` clause. The sequence can be empty if [... from ...] is enclosed in brackets.

If $A$ is an aggregate expression like in the first column, then the expression in the third column is another aggregate expression whose type is defined in the fourth column and which evaluates to the value of the single property in the single instance in the output set of the expression in the fifth column. This rule can be applied repeatedly and lead to multiple `from` clauses in one aggregate expression.

|Aggregate expression|type of $A$|Aggregate-from expression|type|evaluates to|
|---|---|---|---|---|
|$A$|1, 2 or 3|$A$ from $P_1,…,P_n$ with $M$|1|groupby(($P_1,…,P_n$), aggregate($A$ as $A_1$))/aggregate($A_1$ with $M$ as $D$)|
|$A=C$ [... from ...]|4|$A$ from $P_1,…,P_n$ with $M$|1|groupby(($P_1,…,P_n$), aggregate($A$))/aggregate($C$ with $M$ as $D$)|
|$A=C$ [... from ...]|4|$A$ from $P_1,…,P_n$|4|groupby(($P_1,…,P_n$), aggregate($A$))/aggregate($C$)|
|$A=C$ ... from ... with $M$|1|$A$ from $P_1,…,P_n$|4|groupby(($P_1,…,P_n$), aggregate($A$ as $A_1$))/aggregate($C$)|