### PR TITLE
Walkthrough OData-Aggr 3.2

### DIFF
--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -107,17 +107,17 @@ preservingTrafo = bottomcountTrafo
                 / customFunction ; custom functions could be preserving, hence are allowed in preservingTrafos
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
 
-aggregateTrafo  = %s"aggregate" OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
-aggregateItem   = %s"$count" asAlias 
-                / aggregateCount asAlias
-                / aggregateExpr
+aggregateTrafo  = %s"aggregate" OPEN BWS aggregateExpr *( BWS COMMA BWS aggregateExpr ) BWS CLOSE
 aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
+                / %s"$count" [ aggregateFrom ] asAlias
+                / aggregateCount [ aggregateFrom ] asAlias
+                / [ aggrPathPrefix "/" ] customAggregate [ customFromAlias asAlias / customFrom ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
-aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
-customFrom      = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
+aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]  ; 3.2.1.5, rule 1
+customFrom      = RWS %s"from" RWS groupingProperties [ [ aggregateWith ] customFrom ] ; 3.2.1.5, rule 3 or 4
+customFromAlias = customFrom aggregateWith                                             ; 3.2.1.5, rule 2
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"
@@ -259,11 +259,11 @@ customFunction  = namespace "." ( entityColFunction / complexColFunction / primi
 isdefinedExpr = %s"isdefined" OPEN BWS ( firstMemberExpr ) BWS CLOSE
 
 aggregateMethodCallExpr = %s"aggregate" OPEN BWS lambdaVariableExpr BWS COLON BWS aggregateFunctionExpr BWS CLOSE
-aggregateFunctionExpr   = %s"$count"
-                          / [ inscopeVariableExpr "/" ] aggregatableExpr aggregateWith [ aggregateFrom ]
-                          / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
-                          / [ inscopeVariableExpr "/" ] aggregateCount
-                          / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom ]
+aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregateWith [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom / customFromAlias ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -144,7 +144,8 @@ aggrPropPath = ( complexProperty          / complexColProperty          ) [ [ "/
 aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ] "/" aggrPrimPath
              / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ] "/" aggrPrimPath
              /   primitiveProperty        / primitiveColProperty
-
+             /   streamProperty
+             
 nestPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" nestPropPath ]
 
 snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglPropPath ]
@@ -152,6 +153,7 @@ snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeNa
 snglPrimPath = complexProperty            [ "/" optionallyQualifiedComplexTypeName ] "/" snglPrimPath
              / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPrimPath
              / primitiveProperty
+             / streamProperty
 
 aggregatableFactor = decimalValue / doubleValue / singleValue / sbyteValue
                    / byteValue    / int16Value  / int32Value  / int64Value

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -112,12 +112,11 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
                 / %s"$count" [ aggregateFrom ] asAlias
                 / aggregateCount [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ customFromAlias asAlias / customFrom ]
+                / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
-aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]  ; 3.2.1.5, rule 1
-customFrom      = RWS %s"from" RWS groupingProperties [ [ aggregateWith ] customFrom ] ; 3.2.1.5, rule 3 or 4
-customFromAlias = customFrom aggregateWith                                             ; 3.2.1.5, rule 2
+aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
+customFrom      = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"
@@ -263,7 +262,7 @@ aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregate
                         / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
-                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFromAlias / customFrom ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -112,7 +112,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
                 / %s"$count" [ aggregateFrom ] asAlias
                 / aggregateCount [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
+                / [ aggrPathPrefix "/" ] customAggregate [ [ customFrom ] asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -263,7 +263,7 @@ aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregate
                         / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
-                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom / customFromAlias ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFromAlias / customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -425,7 +425,7 @@ TestCases:
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time as DailyAverage)
+    Input: $apply=aggregate(Forecast from Time as Stuff)
 
   - Name: aggregate - path with key segment
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -753,7 +753,7 @@ TestCases:
 
   - Name: custom aggregates - entity set
     Rule: odataRelativeUri
-    Input: Sales?$apply=groupby((Time/Month),aggregate(Forecast))
+    Input: Sales?$apply=groupby((Time/Month),aggregate(Forecast as Stuff))
 
   - Name: custom aggregates - crossjoin
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -484,10 +484,17 @@ TestCases:
     Rule: queryOptions
     Input: $apply=groupby((Product/Name,Amount))
 
-  - Name: aggregate - no groupby stream property
+  - Name: aggregate - groupby stream property
     Rule: queryOptions
-    FailAt: 29
     Input: $apply=groupby((Product/Image))
+    Expect:
+      - snglPrimPath:Product/Image
+
+  - Name: aggregate - groupby complex property
+    Rule: queryOptions
+    Input: $apply=groupby((Product/ShipTo))
+    Expect:
+      - snglPropPath:Product/ShipTo
 
   - Name: aggregate - groupby annotations
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -569,7 +569,8 @@ TestCases:
           IncludeSelf=true)),
         SalesOrgHierarchy,
         SalesOrganization/ID)),
-      aggregate(Amount with sum as Total))
+      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
+        SalesOrgHierarchy,SalesOrganization/ID,preorder)
 
   - Name: aggregate - filter
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -406,9 +406,10 @@ TestCases:
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average as DailyAverage)
 
-  - Name: aggregate - custom aggregate and multiple from
+  - Name: aggregate - custom aggregate and multiple from, missing alias
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time from Product/Name with average as DailyAverage)
+    FailAt: 66
+    Input: $apply=aggregate(Forecast from Time from Product/Name with average)
 
   - Name: aggregate - custom aggregate and from multiple
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -420,10 +420,11 @@ TestCases:
 
   - Name: aggregate - custom aggregate, with, custom aggregate again
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time with average from Product/Name)
+    Input: $apply=aggregate(Forecast from Time with average from Product/Name as DailyAverage)
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
+    FailAt: 35
     Input: $apply=aggregate(Forecast from Time)
 
   - Name: aggregate - path with key segment

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -550,6 +550,20 @@ TestCases:
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
       SalesOrgCount))
 
+  - Name: aggregate - groupby rollup recursive sub-hierarchy
+    Rule: queryOptions
+    Input: $apply=groupby((rolluprecursive(
+        $root/SalesOrganizations/$filter(Aggregation.isdescendant(
+          HierarchyNodes=$root/SalesOrganizations,
+          HierarchyQualifier='SalesOrgHierarchy',
+          Node=ID,
+          Ancestor='EMEA',
+          MaxDistance=2,
+          IncludeSelf=true)),
+        SalesOrgHierarchy,
+        SalesOrganization/ID)),
+      aggregate(Amount with sum as Total))
+
   - Name: aggregate - filter
     Rule: queryOptions
     Input: $apply=filter(Amount gt 3)

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -392,6 +392,10 @@ TestCases:
     FailAt: 24
     Input: $apply=aggregate(Amount from Time with average as DailyAverage)
 
+  - Name: aggregate - $count from
+    Rule: queryOptions
+    Input: $apply=aggregate(Sales/$count from Time with average as DailyAverage)
+
   - Name: aggregate - custom aggregate reached via path
     Rule: queryOptions
     Input: $apply=aggregate(Sales/Forecast)
@@ -416,11 +420,11 @@ TestCases:
 
   - Name: aggregate - custom aggregate, with, custom aggregate again
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time with average from Product/Name as DailyAverage)
+    Input: $apply=aggregate(Forecast from Time with average from Product/Name)
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time as Stuff)
+    Input: $apply=aggregate(Forecast from Time)
 
   - Name: aggregate - path with key segment
     Rule: queryOptions
@@ -699,9 +703,9 @@ TestCases:
       $apply=compute(Amount div $these/aggregate(p:Amount with sum from Time
       with average) as RelativeAmount)
 
-  - Name: aggregate function - across input set with $count
+  - Name: aggregate function - across input set with $count and from
     Rule: queryOptions
-    Input: $apply=compute($these/aggregate(p:$count) as SalesCount)
+    Input: $apply=compute($these/aggregate(p:$count from Product with max) as SalesCount)
 
   - Name: aggregate function - across input set with $count
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -425,8 +425,7 @@ TestCases:
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    FailAt: 35
-    Input: $apply=aggregate(Forecast from Time)
+    Input: $apply=aggregate(Forecast from Time as DailyAverage)
 
   - Name: aggregate - path with key segment
     Rule: queryOptions


### PR DESCRIPTION
* Allow `$count from ... with ...`
* Allow an alias after a custom aggregate
* Always require an alias after `from`
* Allow `groupby` stream and complex properties