### PR TITLE
Optional parameters for rolluprecursive

### DIFF
--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -251,7 +251,7 @@ traverseRecursive = %s"traverserecursive" OPEN BWS
                     [ COMMA BWS hierarchyTrafos BWS ]
                     [ COMMA BWS traverseOrder BWS ]
                     CLOSE
-traverseOrder     = ( %s"preorderby" / %s"postorderby" ) OPEN BWS
+traverseOrder     = ( %s"preorder" / %s"postorder" ) OPEN BWS
                     [ orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ] CLOSE
 
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -235,7 +235,10 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS
+                    [ COMMA BWS preservingTrafos BWS ]
+                    [ COMMA BWS 1*DIGIT BWS ]
+                    CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -128,7 +128,7 @@ aggregateMethod = %s"sum"
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
 aggregateCount  = optionalLeadingTypeCast ( complexColProperty / entityColNavigationProperty / primitiveColProperty ) %s"/$count"
-                / aggrPathPrefix aggregateCount
+                / aggrPathPrefix "/" aggregateCount
 optionalLeadingTypeCast = [ ( optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName ) "/" ]
 
 asAlias         = RWS %s"as" RWS expressionAlias

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -251,8 +251,8 @@ traverseRecursive = %s"traverserecursive" OPEN BWS
                     [ COMMA BWS hierarchyTrafos BWS ]
                     [ COMMA BWS traverseOrder BWS ]
                     CLOSE
-traverseOrder     = ( %s"preorder" / %s"postorder" ) OPEN BWS
-                    [ orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ] CLOSE
+traverseOrder     = ( %s"preorder" / %s"postorder" )
+                    [ OPEN BWS orderbyItem *( BWS COMMA BWS orderbyItem ) BWS CLOSE ]
 
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -107,17 +107,17 @@ preservingTrafo = bottomcountTrafo
                 / customFunction ; custom functions could be preserving, hence are allowed in preservingTrafos
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
 
-aggregateTrafo  = %s"aggregate" OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
-aggregateItem   = %s"$count" asAlias 
-                / aggregateCount asAlias
-                / aggregateExpr
+aggregateTrafo  = %s"aggregate" OPEN BWS aggregateExpr *( BWS COMMA BWS aggregateExpr ) BWS CLOSE
 aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
+                / %s"$count" [ aggregateFrom ] asAlias
+                / aggregateCount [ aggregateFrom ] asAlias
+                / [ aggrPathPrefix "/" ] customAggregate [ customFromAlias asAlias / customFrom ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
-aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
-customFrom      = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
+aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]  ; 3.2.1.5, rule 1
+customFrom      = RWS %s"from" RWS groupingProperties [ [ aggregateWith ] customFrom ] ; 3.2.1.5, rule 3 or 4
+customFromAlias = customFrom aggregateWith                                             ; 3.2.1.5, rule 2
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"
@@ -259,11 +259,11 @@ customFunction  = namespace "." ( entityColFunction / complexColFunction / primi
 isdefinedExpr = %s"isdefined" OPEN BWS ( firstMemberExpr ) BWS CLOSE
 
 aggregateMethodCallExpr = %s"aggregate" OPEN BWS lambdaVariableExpr BWS COLON BWS aggregateFunctionExpr BWS CLOSE
-aggregateFunctionExpr   = %s"$count"
-                          / [ inscopeVariableExpr "/" ] aggregatableExpr aggregateWith [ aggregateFrom ]
-                          / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
-                          / [ inscopeVariableExpr "/" ] aggregateCount
-                          / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom ]
+aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregateWith [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom / customFromAlias ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -224,7 +224,7 @@ recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA BWS recHierQualifier
                    BWS COMMA BWS recHierPropertyPath
 recHierQualifier = odataIdentifier
-recHierPropertyPath = optionalLeadingTypeCast aggrPrimPath
+recHierPropertyPath = [ aggrCastPath "/" ] aggrPrimPath
 
 filterTrafo     = %s"filter" OPEN BWS boolCommonExpr BWS CLOSE
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -151,11 +151,8 @@ aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/
              
 nestPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" nestPropPath ]
 
-snglCmpPPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglCmpPPath ]
-             / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglCmpPPath
-snglNavPPath = complexProperty            [ "/" optionallyQualifiedComplexTypeName ] "/" snglNavPPath
-             / entityNavigationProperty [ [ "/" optionallyQualifiedEntityTypeName  ] "/" snglNavPPath ]
-snglPropPath = snglCmpPPath / snglNavPPath
+snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglPropPath ]
+             / entityNavigationProperty [ [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPropPath ]
 snglPrimPath = complexProperty            [ "/" optionallyQualifiedComplexTypeName ] "/" snglPrimPath
              / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPrimPath
              / primitiveProperty
@@ -233,15 +230,7 @@ recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA BWS recHierQualifier
                    BWS COMMA BWS recHierPropertyPath
 recHierQualifier = odataIdentifier
-recHierPropertyPath = optionalLeadingTypeCast snglPrimPath
-                    / optionalLeadingTypeCast
-                      [ snglCmpPPath [ "/" optionallyQualifiedComplexTypeName ] "/"
-                      / snglNavPPath [ "/" optionallyQualifiedEntityTypeName  ] "/" ]
-                      ( ( complexColProperty          [ "/" optionallyQualifiedComplexTypeName ]
-                        / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName  ] )
-                        "/" snglPrimPath
-                      / primitiveColProperty
-                      )
+recHierPropertyPath = optionalLeadingTypeCast aggrPrimPath
 
 filterTrafo     = %s"filter" OPEN BWS boolCommonExpr BWS CLOSE
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -226,7 +226,10 @@ hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ
                    rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA BWS recHierQualifier
 recHierQualifier = odataIdentifier
-recHierPropertyPath = *( ( complexProperty / entityNavigationProperty ) "/" ) primitiveProperty
+recHierPropertyPath = optionalLeadingTypeCast snglPrimPath
+recHierRollupPPath  = optionalLeadingTypeCast
+                      [ [ snglPropPath ] ( complexColProperty / entityColNavigationProperty ) ] snglPrimPath
+                    / optionalLeadingTypeCast [ snglPropPath ] primitiveColProperty
 
 filterTrafo     = %s"filter" OPEN BWS boolCommonExpr BWS CLOSE
 
@@ -237,7 +240,7 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierPropertyPath [ BWS COMMA BWS hierarchyTrafos ] BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierRollupPPath [ BWS COMMA BWS hierarchyTrafos ] BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -236,8 +236,7 @@ groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS
-                    [ COMMA BWS preservingTrafos BWS ]
-                    [ COMMA BWS 1*DIGIT BWS ]
+                    [ COMMA BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] ]
                     CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -127,7 +127,11 @@ aggregateMethod = %s"sum"
                 / nonprimAggMethod
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
-aggregateCount  = optionalLeadingTypeCast ( complexColProperty / entityColNavigationProperty / primitiveColProperty ) %s"/$count"
+aggregateCount  = optionalLeadingTypeCast
+                  ( complexColProperty [ "/" optionallyQualifiedComplexTypeName ]
+                  / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName ]
+                  / primitiveColProperty
+                  ) %s"/$count"
                 / aggrPathPrefix aggregateCount
 optionalLeadingTypeCast = [ ( optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName ) "/" ]
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -236,7 +236,8 @@ groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS
-                    [ COMMA BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] ]
+                    [ COMMA BWS %s"descendants" OPEN BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] CLOSE BWS ]
+                    [ COMMA BWS %s"ancestors" OPEN BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] CLOSE BWS ]
                     CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -144,7 +144,8 @@ aggrPropPath = ( complexProperty          / complexColProperty          ) [ [ "/
 aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ] "/" aggrPrimPath
              / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ] "/" aggrPrimPath
              /   primitiveProperty        / primitiveColProperty
-
+             /   streamProperty
+             
 nestPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" nestPropPath ]
 
 snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglPropPath ]
@@ -152,6 +153,7 @@ snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeNa
 snglPrimPath = complexProperty            [ "/" optionallyQualifiedComplexTypeName ] "/" snglPrimPath
              / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPrimPath
              / primitiveProperty
+             / streamProperty
 
 aggregatableFactor = decimalValue / doubleValue / singleValue / sbyteValue
                    / byteValue    / int16Value  / int32Value  / int64Value

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -240,7 +240,7 @@ recHierRollupPPath  = recHierPropertyPath
                       / snglNavPPath [ "/" optionallyQualifiedEntityTypeName  ] "/" ]
                       ( ( complexColProperty          [ "/" optionallyQualifiedComplexTypeName ]
                         / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName  ] )
-                        snglPrimPath
+                        "/" snglPrimPath
                       / primitiveColProperty
                       )
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -238,14 +238,22 @@ searchTrafo     = %s"search" OPEN BWS searchExpr BWS CLOSE
 
 groupbyTrafo    = %s"groupby" OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] BWS CLOSE
 groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS CLOSE
-groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
+groupbyElement  = groupingProperty / rollupLevels / rollupRecursive / traverseRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupRecursive   = %s"rolluprecursive" OPEN BWS
                     recHierReference BWS
                     [ COMMA BWS hierarchyTrafos BWS ]
+                    [ COMMA BWS traverseOrder BWS ]
                     CLOSE
- 
+traverseRecursive = %s"traverserecursive" OPEN BWS
+                    recHierReference BWS
+                    [ COMMA BWS hierarchyTrafos BWS ]
+                    [ COMMA BWS traverseOrder BWS ]
+                    CLOSE
+traverseOrder     = ( %s"preorderby" / %s"postorderby" ) OPEN BWS
+                    [ orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ] CLOSE
+
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -112,12 +112,11 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
                 / %s"$count" [ aggregateFrom ] asAlias
                 / aggregateCount [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ customFromAlias asAlias / customFrom ]
+                / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
-aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]  ; 3.2.1.5, rule 1
-customFrom      = RWS %s"from" RWS groupingProperties [ [ aggregateWith ] customFrom ] ; 3.2.1.5, rule 3 or 4
-customFromAlias = customFrom aggregateWith                                             ; 3.2.1.5, rule 2
+aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
+customFrom      = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
 aggregateMethod = %s"sum"
                 / %s"min"
                 / %s"max"
@@ -263,7 +262,7 @@ aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregate
                         / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
-                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFromAlias / customFrom ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -127,11 +127,7 @@ aggregateMethod = %s"sum"
                 / nonprimAggMethod
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
-aggregateCount  = optionalLeadingTypeCast
-                  ( complexColProperty [ "/" optionallyQualifiedComplexTypeName ]
-                  / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName ]
-                  / primitiveColProperty
-                  ) %s"/$count"
+aggregateCount  = optionalLeadingTypeCast ( complexColProperty / entityColNavigationProperty / primitiveColProperty ) %s"/$count"
                 / aggrPathPrefix aggregateCount
 optionalLeadingTypeCast = [ ( optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName ) "/" ]
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -112,7 +112,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
                 / %s"$count" [ aggregateFrom ] asAlias
                 / aggregateCount [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ customFrom asAlias ]
+                / [ aggrPathPrefix "/" ] customAggregate [ [ customFrom ] asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -115,7 +115,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
                 / %s"$count" [ aggregateFrom ] asAlias
                 / aggregateCount [ aggregateFrom ] asAlias
-                / aggregateCustom [ [ customFrom ] asAlias ]
+                / [ aggrPathPrefix "/" ] customAggregate [ [ customFrom ] asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
@@ -127,9 +127,12 @@ aggregateMethod = %s"sum"
                 / nonprimAggMethod
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
-aggregateCount  = ( optionalLeadingTypeCast aggrCollPath / aggrCastPath ) %s"/$count"
-                / [ aggrPathPrefix "/" ] optionalLeadingTypeCast primitiveColProperty %s"/$count"
-aggregateCustom = [ ( aggrPathPrefix / aggrCastPath ) "/" ] customAggregate
+aggregateCount  = optionalLeadingTypeCast
+                  ( complexColProperty [ "/" optionallyQualifiedComplexTypeName ]
+                  / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName ]
+                  / primitiveColProperty
+                  ) %s"/$count"
+                / aggrPathPrefix aggregateCount
 optionalLeadingTypeCast = [ ( optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName ) "/" ]
 
 asAlias         = RWS %s"as" RWS expressionAlias
@@ -143,13 +146,13 @@ customAggregate = odataIdentifier
 ; - one for use in transformnested and addnested, without entity-valued segments (rule with prefix nest)
 ; A type cast (optionallyQualifiedComplexTypeName or optionallyQualifiedEntityTypeName) cannot be the final segment in them.
 ; Term casts are not allowed in data aggregation paths.
-aggrPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ]   "/" aggrPropPath ]
-             / ( entityNavigationProperty / entityColNavigationProperty ) [ [ "/" optionallyQualifiedEntityTypeName  ]   "/" aggrPropPath ]
-aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ]   "/" aggrPrimPath
-             / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ]   "/" aggrPrimPath
+aggrPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" aggrPropPath ]
+             / ( entityNavigationProperty / entityColNavigationProperty ) [ [ "/" optionallyQualifiedEntityTypeName  ] "/" aggrPropPath ]
+aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ] "/" aggrPrimPath
+             / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ] "/" aggrPrimPath
              /   primitiveProperty        / primitiveColProperty
              /   streamProperty
-
+             
 nestPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" nestPropPath ]
 
 snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglPropPath ]
@@ -158,14 +161,6 @@ snglPrimPath = complexProperty            [ "/" optionallyQualifiedComplexTypeNa
              / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPrimPath
              / primitiveProperty
              / streamProperty
-
-; Certain variants of aggregate allow paths with a final type cast segment.
-aggrCollStep = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ]
-             / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ]
-aggrCollPath = complexColProperty          [ "/" optionallyQualifiedComplexTypeName ]
-             / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName  ]
-             / aggrCollStep "/" aggrCollPath
-aggrCastPath = optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName
 
 aggregatableFactor = decimalValue / doubleValue / singleValue / sbyteValue
                    / byteValue    / int16Value  / int32Value  / int64Value
@@ -181,7 +176,7 @@ aggregatableArith  = [ "-" BWS ] aggregatableTerm *( RWS ( "add" / "sub" ) RWS a
 aggregatableExpr   = aggregatableArith
                    / aggrPathPrimitive
 aggrPathPrimitive  = optionalLeadingTypeCast aggrPrimPath
-aggrPathPrefix     = optionalLeadingTypeCast ( aggrCollPath / aggrPropPath )
+aggrPathPrefix     = optionalLeadingTypeCast aggrPropPath
 groupingProperty   = optionalLeadingTypeCast ( snglPrimPath / snglPropPath )
 groupingProperties = groupingProperty *( BWS COMMA BWS groupingProperty )
 
@@ -283,7 +278,7 @@ aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregate
                         / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
-                        / [ inscopeVariableExpr "/" ] aggregateCustom [ customFrom ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -115,7 +115,7 @@ aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
                 / aggrPathPrefix nonprimAggWith [ aggregateFrom ] asAlias
                 / %s"$count" [ aggregateFrom ] asAlias
                 / aggregateCount [ aggregateFrom ] asAlias
-                / [ aggrPathPrefix "/" ] customAggregate [ [ customFrom ] asAlias ]
+                / aggregateCustom [ [ customFrom ] asAlias ]
 aggregateWith   = RWS %s"with" RWS aggregateMethod
 nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
 aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
@@ -127,12 +127,9 @@ aggregateMethod = %s"sum"
                 / nonprimAggMethod
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
-aggregateCount  = optionalLeadingTypeCast
-                  ( complexColProperty [ "/" optionallyQualifiedComplexTypeName ]
-                  / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName ]
-                  / primitiveColProperty
-                  ) %s"/$count"
-                / aggrPathPrefix aggregateCount
+aggregateCount  = ( optionalLeadingTypeCast aggrCollPath / aggrCastPath ) %s"/$count"
+                / [ aggrPathPrefix "/" ] optionalLeadingTypeCast primitiveColProperty %s"/$count"
+aggregateCustom = [ ( aggrPathPrefix / aggrCastPath ) "/" ] customAggregate
 optionalLeadingTypeCast = [ ( optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName ) "/" ]
 
 asAlias         = RWS %s"as" RWS expressionAlias
@@ -146,13 +143,13 @@ customAggregate = odataIdentifier
 ; - one for use in transformnested and addnested, without entity-valued segments (rule with prefix nest)
 ; A type cast (optionallyQualifiedComplexTypeName or optionallyQualifiedEntityTypeName) cannot be the final segment in them.
 ; Term casts are not allowed in data aggregation paths.
-aggrPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" aggrPropPath ]
-             / ( entityNavigationProperty / entityColNavigationProperty ) [ [ "/" optionallyQualifiedEntityTypeName  ] "/" aggrPropPath ]
-aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ] "/" aggrPrimPath
-             / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ] "/" aggrPrimPath
+aggrPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ]   "/" aggrPropPath ]
+             / ( entityNavigationProperty / entityColNavigationProperty ) [ [ "/" optionallyQualifiedEntityTypeName  ]   "/" aggrPropPath ]
+aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ]   "/" aggrPrimPath
+             / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ]   "/" aggrPrimPath
              /   primitiveProperty        / primitiveColProperty
              /   streamProperty
-             
+
 nestPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" nestPropPath ]
 
 snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglPropPath ]
@@ -161,6 +158,14 @@ snglPrimPath = complexProperty            [ "/" optionallyQualifiedComplexTypeNa
              / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPrimPath
              / primitiveProperty
              / streamProperty
+
+; Certain variants of aggregate allow paths with a final type cast segment.
+aggrCollStep = ( complexProperty          / complexColProperty          )   [ "/" optionallyQualifiedComplexTypeName ]
+             / ( entityNavigationProperty / entityColNavigationProperty )   [ "/" optionallyQualifiedEntityTypeName  ]
+aggrCollPath = complexColProperty          [ "/" optionallyQualifiedComplexTypeName ]
+             / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName  ]
+             / aggrCollStep "/" aggrCollPath
+aggrCastPath = optionallyQualifiedComplexTypeName / optionallyQualifiedEntityTypeName
 
 aggregatableFactor = decimalValue / doubleValue / singleValue / sbyteValue
                    / byteValue    / int16Value  / int32Value  / int64Value
@@ -176,7 +181,7 @@ aggregatableArith  = [ "-" BWS ] aggregatableTerm *( RWS ( "add" / "sub" ) RWS a
 aggregatableExpr   = aggregatableArith
                    / aggrPathPrimitive
 aggrPathPrimitive  = optionalLeadingTypeCast aggrPrimPath
-aggrPathPrefix     = optionalLeadingTypeCast aggrPropPath
+aggrPathPrefix     = optionalLeadingTypeCast ( aggrCollPath / aggrPropPath )
 groupingProperty   = optionalLeadingTypeCast ( snglPrimPath / snglPropPath )
 groupingProperties = groupingProperty *( BWS COMMA BWS groupingProperty )
 
@@ -278,7 +283,7 @@ aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregate
                         / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
-                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom ]
+                        / [ inscopeVariableExpr "/" ] aggregateCustom [ customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -102,7 +102,7 @@ preservingTrafo = bottomcountTrafo
                 / topcountTrafo
                 / toppercentTrafo
                 / topsumTrafo
-                / customFunction ; custom functions could be preserving, hence are allowed in preservingTrafos
+                / hierarchyTrafo
 hierarchyTrafo  = ancestorsTrafo
                 / descendantsTrafo
                 / traverseTrafo

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -225,6 +225,7 @@ descendantsTrafo = %s"descendants" OPEN BWS
 traverseTrafo   = %s"traverse" OPEN BWS
                   recHierReference BWS
                   COMMA BWS ( %s"preorder" / %s"postorder" ) BWS
+                  [ COMMA BWS hierarchyTrafos BWS ]
                   [ COMMA BWS orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ]
                   CLOSE 
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -63,9 +63,9 @@
 ; 1. New alternatives for OData ABNF Construction Rules
 ;------------------------------------------------------------------------------
 
-systemQueryOption =/ apply
+systemQueryOption =/ apply / hierarchy
 
-expandOption =/ apply
+expandOption =/ apply / hierarchy
 
 boolMethodCallExpr =/ isdefinedExpr
 
@@ -82,16 +82,14 @@ collectionPathExpr =/ "/" aggregateMethodCallExpr
 apply      = ( "$apply" / "apply" ) EQ applyExpr
 applyExpr  = applyTrafo *( "/" applyTrafo )
 applyTrafo = aggregateTrafo
-           / ancestorsTrafo
            / computeTrafo
            / concatTrafo
-           / descendantsTrafo
            / groupbyTrafo
            / joinTrafo
            / nestTrafo
            / outerjoinTrafo
-           / traverseTrafo
            / preservingTrafo
+           / hierarchyTrafo
 preservingTrafo = bottomcountTrafo
                 / bottompercentTrafo
                 / bottomsumTrafo
@@ -105,7 +103,12 @@ preservingTrafo = bottomcountTrafo
                 / toppercentTrafo
                 / topsumTrafo
                 / customFunction ; custom functions could be preserving, hence are allowed in preservingTrafos
+hierarchyTrafo  = ancestorsTrafo
+                / descendantsTrafo
+                / traverseTrafo
+                / customFunction ; custom functions could be hierarchical, hence are allowed in hierarchyTrafos
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
+hierarchyTrafos  = hierarchyTrafo *( "/" hierarchyTrafo )
 
 aggregateTrafo  = %s"aggregate" OPEN BWS aggregateExpr *( BWS COMMA BWS aggregateExpr ) BWS CLOSE
 aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
@@ -200,29 +203,28 @@ joinProperty    = ( complexColProperty
                   / entityAnnotationInQuery  ; must be collection-valued
                   )
 
-ancestorsTrafo  = %s"ancestors" OPEN 
-                  BWS recHierReference BWS 
+ancestorsTrafo  = %s"ancestors" OPEN
+                  BWS recHierPropertyPath BWS
                   COMMA BWS preservingTrafos BWS
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
 
 descendantsTrafo = %s"descendants" OPEN 
-                 BWS recHierReference BWS 
-                 COMMA BWS preservingTrafos BWS
-                 [ COMMA BWS 1*DIGIT BWS ]
-                 [ COMMA BWS %s"keep start" BWS ]
-                 CLOSE
+                  BWS recHierPropertyPath BWS
+                  COMMA BWS preservingTrafos BWS
+                  [ COMMA BWS 1*DIGIT BWS ]
+                  [ COMMA BWS %s"keep start" BWS ]
+                  CLOSE
 
 traverseTrafo   = %s"traverse" OPEN 
-                  BWS recHierReference BWS 
+                  BWS recHierPropertyPath BWS
                   COMMA BWS ( %s"preorder" / %s"postorder" ) BWS 
                   CLOSE 
 
-recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
-                   BWS COMMA
-                   BWS recHierQualifier BWS COMMA
-                   BWS recHierPropertyPath
+hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ
+                   rootExpr ; must have type Collection(Edm.EntityType)
+                   BWS COMMA BWS recHierQualifier
 recHierQualifier = odataIdentifier
 recHierPropertyPath = *( ( complexProperty / entityNavigationProperty ) "/" ) primitiveProperty
 
@@ -235,10 +237,7 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS
-                    *( COMMA BWS ( %s"ancestors" / %s"descendants" )
-                       OPEN BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] CLOSE BWS )
-                    CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierPropertyPath [ BWS COMMA BWS hierarchyTrafos ] BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -263,7 +263,7 @@ aggregateFunctionExpr   = [ inscopeVariableExpr "/" ] aggregatableExpr aggregate
                         / [ inscopeVariableExpr "/" ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] %s"$count" [ aggregateFrom ]
                         / [ inscopeVariableExpr "/" ] aggregateCount [ aggregateFrom ]
-                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFrom / customFromAlias ]
+                        / [ inscopeVariableExpr "/" ] [ aggrPathPrefix "/" ] customAggregate [ customFromAlias / customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -201,7 +201,7 @@ joinProperty    = ( complexColProperty
 ancestorsTrafo  = %s"ancestors" OPEN BWS
                   recHierReference BWS
                   COMMA BWS preservingTrafos BWS
-                  [ COMMA BWS hierarchyTrafos BWS ]
+                  [ COMMA BWS preservingTrafos BWS ]
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
@@ -209,7 +209,7 @@ ancestorsTrafo  = %s"ancestors" OPEN BWS
 descendantsTrafo = %s"descendants" OPEN BWS
                   recHierReference BWS
                   COMMA BWS preservingTrafos BWS
-                  [ COMMA BWS hierarchyTrafos BWS ]
+                  [ COMMA BWS preservingTrafos BWS ]
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
@@ -217,7 +217,7 @@ descendantsTrafo = %s"descendants" OPEN BWS
 traverseTrafo   = %s"traverse" OPEN BWS
                   recHierReference BWS
                   COMMA BWS ( %s"preorder" / %s"postorder" ) BWS
-                  [ COMMA BWS hierarchyTrafos BWS ]
+                  [ COMMA BWS preservingTrafos BWS ]
                   [ COMMA BWS orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ]
                   CLOSE 
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -238,21 +238,13 @@ searchTrafo     = %s"search" OPEN BWS searchExpr BWS CLOSE
 
 groupbyTrafo    = %s"groupby" OPEN BWS groupbyList [ BWS COMMA BWS applyExpr ] BWS CLOSE
 groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS CLOSE
-groupbyElement  = groupingProperty / rollupLevels / rollupRecursive / traverseRecursive
+groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupRecursive   = %s"rolluprecursive" OPEN BWS
                     recHierReference BWS
                     [ COMMA BWS hierarchyTrafos BWS ]
-                    [ COMMA BWS traverseOrder BWS ]
                     CLOSE
-traverseRecursive = %s"traverserecursive" OPEN BWS
-                    recHierReference BWS
-                    [ COMMA BWS hierarchyTrafos BWS ]
-                    [ COMMA BWS traverseOrder BWS ]
-                    CLOSE
-traverseOrder     = ( %s"preorder" / %s"postorder" )
-                    [ OPEN BWS orderbyItem *( BWS COMMA BWS orderbyItem ) BWS CLOSE ]
 
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -203,27 +203,31 @@ joinProperty    = ( complexColProperty
                   / entityAnnotationInQuery  ; must be collection-valued
                   )
 
-ancestorsTrafo  = %s"ancestors" OPEN
-                  BWS recHierPropertyPath BWS
+ancestorsTrafo  = %s"ancestors" OPEN BWS
+                  [ recHierReference BWS COMMA BWS ]
+                  recHierPropertyPath BWS
                   COMMA BWS preservingTrafos BWS
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
 
-descendantsTrafo = %s"descendants" OPEN 
-                  BWS recHierPropertyPath BWS
+descendantsTrafo = %s"descendants" OPEN BWS
+                  [ recHierReference BWS COMMA BWS ]
+                  recHierPropertyPath BWS
                   COMMA BWS preservingTrafos BWS
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
 
-traverseTrafo   = %s"traverse" OPEN 
-                  BWS recHierPropertyPath BWS
-                  COMMA BWS ( %s"preorder" / %s"postorder" ) BWS 
+traverseTrafo   = %s"traverse" OPEN BWS
+                  [ recHierReference BWS COMMA BWS ]
+                  recHierPropertyPath BWS
+                  COMMA BWS ( %s"preorder" / %s"postorder" ) BWS
+                  [ COMMA BWS orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ]
                   CLOSE 
 
-hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ
-                   rootExpr ; must have type Collection(Edm.EntityType)
+hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ recHierReference
+recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA BWS recHierQualifier
 recHierQualifier = odataIdentifier
 recHierPropertyPath = optionalLeadingTypeCast snglPrimPath
@@ -240,7 +244,9 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierRollupPPath [ BWS COMMA BWS hierarchyTrafos ] BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN
+                    [ BWS recHierReference BWS COMMA ]
+                    BWS recHierRollupPPath [ BWS COMMA BWS hierarchyTrafos ] BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 
@@ -253,7 +259,7 @@ topsumTrafo     = %s"topsum"     OPEN BWS commonExpr BWS COMMA BWS commonExpr BW
 topTrafo        = %s"top" OPEN BWS 1*DIGIT BWS CLOSE
 skipTrafo       = %s"skip" OPEN BWS 1*DIGIT BWS CLOSE
 
-orderbyTrafo    = %s"orderby" OPEN orderbyItem *( COMMA orderbyItem ) CLOSE
+orderbyTrafo    = %s"orderby" OPEN orderbyItem *( BWS COMMA BWS orderbyItem ) CLOSE
 
 customFunction  = namespace "." ( entityColFunction / complexColFunction / primitiveColFunction ) functionExprParameters
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -236,8 +236,8 @@ groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS
-                    [ COMMA BWS %s"descendants" OPEN BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] CLOSE BWS ]
-                    [ COMMA BWS %s"ancestors" OPEN BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] CLOSE BWS ]
+                    *( COMMA BWS ( %s"ancestors" / %s"descendants" )
+                       OPEN BWS preservingTrafos BWS [ COMMA BWS 1*DIGIT BWS ] CLOSE BWS )
                     CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -151,8 +151,11 @@ aggrPrimPath = ( complexProperty          / complexColProperty          )   [ "/
              
 nestPropPath = ( complexProperty          / complexColProperty          ) [ [ "/" optionallyQualifiedComplexTypeName ] "/" nestPropPath ]
 
-snglPropPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglPropPath ]
-             / entityNavigationProperty [ [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPropPath ]
+snglCmpPPath = complexProperty          [ [ "/" optionallyQualifiedComplexTypeName ] "/" snglCmpPPath ]
+             / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglCmpPPath
+snglNavPPath = complexProperty            [ "/" optionallyQualifiedComplexTypeName ] "/" snglNavPPath
+             / entityNavigationProperty [ [ "/" optionallyQualifiedEntityTypeName  ] "/" snglNavPPath ]
+snglPropPath = snglCmpPPath / snglNavPPath
 snglPrimPath = complexProperty            [ "/" optionallyQualifiedComplexTypeName ] "/" snglPrimPath
              / entityNavigationProperty   [ "/" optionallyQualifiedEntityTypeName  ] "/" snglPrimPath
              / primitiveProperty
@@ -231,9 +234,15 @@ recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA BWS recHierQualifier
 recHierQualifier = odataIdentifier
 recHierPropertyPath = optionalLeadingTypeCast snglPrimPath
-recHierRollupPPath  = optionalLeadingTypeCast
-                      [ [ snglPropPath ] ( complexColProperty / entityColNavigationProperty ) ] snglPrimPath
-                    / optionalLeadingTypeCast [ snglPropPath ] primitiveColProperty
+recHierRollupPPath  = recHierPropertyPath
+                    / optionalLeadingTypeCast
+                      [ snglCmpPPath [ "/" optionallyQualifiedComplexTypeName ] "/"
+                      / snglNavPPath [ "/" optionallyQualifiedEntityTypeName  ] "/" ]
+                      ( ( complexColProperty          [ "/" optionallyQualifiedComplexTypeName ]
+                        / entityColNavigationProperty [ "/" optionallyQualifiedEntityTypeName  ] )
+                        snglPrimPath
+                      / primitiveColProperty
+                      )
 
 filterTrafo     = %s"filter" OPEN BWS boolCommonExpr BWS CLOSE
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -63,9 +63,9 @@
 ; 1. New alternatives for OData ABNF Construction Rules
 ;------------------------------------------------------------------------------
 
-systemQueryOption =/ apply / hierarchy
+systemQueryOption =/ apply
 
-expandOption =/ apply / hierarchy
+expandOption =/ apply
 
 boolMethodCallExpr =/ isdefinedExpr
 
@@ -207,34 +207,32 @@ joinProperty    = ( complexColProperty
                   )
 
 ancestorsTrafo  = %s"ancestors" OPEN BWS
-                  [ recHierReference BWS COMMA BWS ]
-                  recHierPropertyPath BWS
+                  recHierReference BWS
                   COMMA BWS preservingTrafos BWS
+                  [ COMMA BWS hierarchyTrafos BWS ]
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
 
 descendantsTrafo = %s"descendants" OPEN BWS
-                  [ recHierReference BWS COMMA BWS ]
-                  recHierPropertyPath BWS
+                  recHierReference BWS
                   COMMA BWS preservingTrafos BWS
+                  [ COMMA BWS hierarchyTrafos BWS ]
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
 
 traverseTrafo   = %s"traverse" OPEN BWS
-                  [ recHierReference BWS COMMA BWS ]
-                  recHierPropertyPath BWS
+                  recHierReference BWS
                   COMMA BWS ( %s"preorder" / %s"postorder" ) BWS
                   [ COMMA BWS orderbyItem *( BWS COMMA BWS orderbyItem ) BWS ]
                   CLOSE 
 
-hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ recHierReference
 recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA BWS recHierQualifier
+                   BWS COMMA BWS recHierPropertyPath
 recHierQualifier = odataIdentifier
 recHierPropertyPath = optionalLeadingTypeCast snglPrimPath
-recHierRollupPPath  = recHierPropertyPath
                     / optionalLeadingTypeCast
                       [ snglCmpPPath [ "/" optionallyQualifiedComplexTypeName ] "/"
                       / snglNavPPath [ "/" optionallyQualifiedEntityTypeName  ] "/" ]
@@ -253,9 +251,11 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN
-                    [ BWS recHierReference BWS COMMA ]
-                    BWS recHierRollupPPath [ BWS COMMA BWS hierarchyTrafos ] BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN BWS
+                    recHierReference BWS
+                    [ COMMA BWS hierarchyTrafos BWS ]
+                    CLOSE
+ 
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -425,7 +425,7 @@ TestCases:
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time as DailyAverage)
+    Input: $apply=aggregate(Forecast from Time as Stuff)
 
   - Name: aggregate - path with key segment
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -623,9 +623,10 @@ TestCases:
         $root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
         descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(ID eq 'EMEA')))),
       aggregate(Amount with sum as Total))/traverse($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
-      preorder,Name desc)
+      preorder,Name desc,ID)
     Expect:
       - orderbyItem:Name desc
+      - orderbyItem:ID
 
   - Name: aggregate - groupby rollup recursive sub-hierarchy with filter
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -753,7 +753,7 @@ TestCases:
 
   - Name: custom aggregates - entity set
     Rule: odataRelativeUri
-    Input: Sales?$apply=groupby((Time/Month),aggregate(Forecast))
+    Input: Sales?$apply=groupby((Time/Month),aggregate(Forecast as Stuff))
 
   - Name: custom aggregates - crossjoin
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -560,8 +560,10 @@ TestCases:
   - Name: aggregate - groupby rollup recursive sub-hierarchy
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive(SalesOrganization/ID,descendants(ID,filter(ID eq 'EMEA')))),
-      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse(SalesOrganization/ID,
-      preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+      aggregate(Amount with sum as Total))/traverse(SalesOrganization/ID,
+      preorder,Name desc)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Expect:
+      - orderbyItem:Name desc
 
   - Name: aggregate - groupby rollup recursive sub-hierarchy with filter
     Rule: queryOptions
@@ -852,8 +854,8 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors
     Rule: queryOptions
-    Input: $apply=ancestors(ID,filter(contains(Name,'East') or
-      contains(Name,'Central')))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
+      contains(Name,'Central')))
 
   - Name: hierarchy transformations - ancestors max distance
     Rule: queryOptions
@@ -1134,8 +1136,8 @@ TestCases:
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rolluprecursive(ID)),
-      aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+      'Paper'))/groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),
+      aggregate(Sales/$count as PaperSalesCount))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1234,6 +1234,22 @@ TestCases:
       )),
       aggregate(Amount with sum as Total))
 
+  - Name: two hierarchies in one transformation sequence - alternative
+    Rule: queryOptions
+    Input: $apply=groupby((rolluprecursive(
+      $root/SalesOrganizations,SalesOrgHierarchy,
+      SalesOrganization/ID,
+      ancestors(
+        $root/SalesOrganizations,SalesOrgHierarchy,
+        ID,
+        descendants(
+          $root/ProductCategories,ProductCategoryHierarchy,
+          ProductCategories/ID,
+          filter(ProductCategories/any(p:p/Name eq 'Car')),
+          keep start))
+      )),
+      aggregate(Amount with sum as Total))
+
   - Name: multi-parent hierarchy with weighted edges
      (ns.SalesOrganization@Aggregation.RecursiveHierarchy#SalesOrgHierarchy/ParentPropertyPath = Edges/Parent)
     Rule: queryOptions
@@ -1242,7 +1258,7 @@ TestCases:
         $root/SalesOrganizations,
         SalesOrgHierarchy,
         SalesOrganization/ID)),
-      compute(Amount mul Self.Weight(Ancestor=Aggregation.rollupnode()) as
+      compute(Amount mul SalesOrganization/Self.Weight(Ancestor=Aggregation.rollupnode()) as
         WeightedAmount)/aggregate(WeightedAmount with sum as TotalAmount))
 
   - Name: aggregation with 1:n hierarchy assignment

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -555,24 +555,27 @@ TestCases:
 
   - Name: aggregate - groupby rollup recursive hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rolluprecursive(ID)),aggregate($count as
-      SalesOrgCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
+      SalesOrgCount))
 
   - Name: aggregate - groupby rollup recursive sub-hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rolluprecursive(SalesOrganization/ID,descendants(ID,filter(ID eq 'EMEA')))),
-      aggregate(Amount with sum as Total))/traverse(SalesOrganization/ID,
-      preorder,Name desc)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=groupby((rolluprecursive(
+        $root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
+        descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(ID eq 'EMEA')))),
+      aggregate(Amount with sum as Total))/traverse($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
+      preorder,Name desc)
     Expect:
       - orderbyItem:Name desc
 
   - Name: aggregate - groupby rollup recursive sub-hierarchy with filter
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive(
-        SalesOrganization/ID,
-        descendants(ID,filter(ID eq 'EMEA'),2,keep start)/ancestors(ID,filter(contains(Name, 'Central')),keep start))),
-      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse(SalesOrganization/ID,
-      preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+        $root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
+        descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(ID eq 'EMEA'),2,keep start)/ancestors(
+        $root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name, 'Central')),keep start))),
+      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse(
+      $root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,preorder)
     Expect:
       - preservingTrafos:filter(ID eq 'EMEA')
       - preservingTrafos:filter(contains(Name, 'Central'))
@@ -844,12 +847,12 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors with forbidden node property path
     Rule: queryOptions
-    FailAt: 25
-    Input: $apply=ancestors(ID,Sales(4711)/ID,identity)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    FailAt: 68
+    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,Sales(4711)/ID,identity)
 
   - Name: hierarchy transformations - ancestors of search result
     Rule: queryOptions
-    Input: $apply=ancestors(ID,search(East)/top(3))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,search(East)/top(3))
     Expect:
       - preservingTrafos:search(East)/top(3)
 
@@ -860,34 +863,34 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors max distance
     Rule: queryOptions
-    Input: $apply=ancestors(ID,filter(contains(Name,'East') or
-      contains(Name,'Central')), 2)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
+      contains(Name,'Central')), 2)
 
   - Name: hierarchy transformations - ancestors hierarchy directory
     Rule: queryOptions
-    Input: $apply=ancestors(ID,filter(contains(Name,'East') or
-      contains(Name,'Central')), keep start)&$hierarchy=$root/SalesOrgHierarchies('DEFAULT')/Nodes,SalesOrgHierarchy
+    Input: $apply=ancestors($root/SalesOrgHierarchies('DEFAULT')/Nodes,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
+      contains(Name,'Central')), keep start)
 
   - Name: hierarchy transformations - ancestors processing non-hierarchical input set; node values via navigation property
     Rule: odataRelativeUri
-    Input: Sales?$apply=ancestors(SalesOrganization/ID,filter(contains(SalesOrganization/Name,'East') or
-      contains(SalesOrganization/Name,'Central')), 2, keep start)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: Sales?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,filter(contains(SalesOrganization/Name,'East') or
+      contains(SalesOrganization/Name,'Central')), 2, keep start)
 
   - Name: hierarchy transformations - descendants
     Rule: queryOptions
-    Input: $apply=descendants(ID,filter(Name eq 'US'))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'))
 
   - Name: hierarchy transformations - descendants max distance
     Rule: queryOptions
-    Input: $apply=descendants(ID,filter(Name eq 'US'), 3)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'), 3)
 
   - Name: hierarchy transformations - descendants keep start
     Rule: queryOptions
-    Input: $apply=descendants(ID,filter(Name eq 'US'),3,keep start)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),3,keep start)
 
   - Name: hierarchy transformations - traverse
     Rule: queryOptions
-    Input: $apply=traverse(ID,preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
 
   - Name: distinct values - no aggregate
     Rule: odataRelativeUri
@@ -1130,9 +1133,9 @@ TestCases:
 
   - Name: transformation sequences - sub-hierarchy selection
     Rule: queryOptions
-    Input: $apply=descendants(ID,filter(Name eq 'US'),keep
-      start)/ancestors(ID,filter(contains(Name,'East')),keep
-      start)/traverse(ID,preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
+    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),keep
+      start)/ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East')),keep
+      start)/traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
 
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
@@ -1143,9 +1146,9 @@ TestCases:
   - Name: two hierarchies in one transformation sequence
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID,
-      ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,
+        ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,
         descendants($root/SalesRepresentatives,SalesRepHierarchy,ID,filter(ID eq 'DE-MA'),keep start),
-      keep start))),
+        keep start))),
       aggregate(Amount with sum as Total))
 
   - Name: aggregation with 1:n hierarchy assignment
@@ -1153,7 +1156,7 @@ TestCases:
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,Suppliers/SalesOrganization/ID)),
       aggregate(Amount with sum as Total))
     Expect:
-      - recHierRollupPPath:Suppliers/SalesOrganization/ID
+      - recHierPropertyPath:Suppliers/SalesOrganization/ID
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -484,10 +484,17 @@ TestCases:
     Rule: queryOptions
     Input: $apply=groupby((Product/Name,Amount))
 
-  - Name: aggregate - no groupby stream property
+  - Name: aggregate - groupby stream property
     Rule: queryOptions
-    FailAt: 29
     Input: $apply=groupby((Product/Image))
+    Expect:
+      - snglPrimPath:Product/Image
+
+  - Name: aggregate - groupby complex property
+    Rule: queryOptions
+    Input: $apply=groupby((Product/ShipTo))
+    Expect:
+      - snglPropPath:Product/ShipTo
 
   - Name: aggregate - groupby annotations
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1159,6 +1159,13 @@ TestCases:
     Expect:
       - recHierPropertyPath:Suppliers/SalesOrganization/ID
 
+  - Name: traverserecursive
+    Rule: queryOptions
+    Input: $apply=groupby((traverserecursive($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
+      preorderby(Name))),identity)
+    Expect:
+      - traverseOrder:preorderby(Name)
+
   - Name: aggregate in $expand
     Rule: odataRelativeUri
     Input: Categories?$expand=Products($apply=aggregate(Price with average as

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -163,6 +163,7 @@ Constraints:
     - Sales_cj
     - SalesOrganizations
     - SalesOrgHierarchies
+    - SalesRepresentatives
     - Time
   entityTypeName:
     - DigitalProduct
@@ -1138,6 +1139,13 @@ TestCases:
     Input: $apply=transformnested(Sales,filter(Product/Name eq
       'Paper'))/groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),
       aggregate(Sales/$count as PaperSalesCount))
+
+  - Name: two hierarchies in one transformation sequence 
+    Rule: queryOptions
+    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID,
+      ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,
+      descendants($root/SalesRepresentatives,SalesRepHierarchy,ID,filter(ID eq 'DE-MA'),keep start),keep start))),
+      aggregate(Amount with sum as Total))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -137,6 +137,7 @@ Constraints:
     - Nodes
     - Orders
     - Products
+    - ProductCategories
     - Profits # dynamic
     - Sales
     - SalesPlan
@@ -161,11 +162,11 @@ Constraints:
     - Customers
     - Products
     - Products_cj
+    - ProductCategories
     - Sales
     - Sales_cj
     - SalesOrganizations
     - SalesOrgHierarchies
-    - SalesRepresentatives
     - Time
   entityTypeName:
     - DigitalProduct
@@ -1150,10 +1151,24 @@ TestCases:
 
   - Name: two hierarchies in one transformation sequence
     Rule: queryOptions
-    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID,
-        ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,
-        descendants($root/SalesRepresentatives,SalesRepHierarchy,ID,filter(ID eq 'DE-MA'),keep start),
-        keep start))),
+    Input: $apply=groupby((rolluprecursive(
+      $root/SalesOrganizations,SalesOrgHierarchy,
+      SalesOrganization/ID,
+      ancestors(
+        $root/SalesOrganizations,SalesOrgHierarchy,
+        ID,
+        traverse(
+          $root/ProductCategories,
+          ProductCategoryHierarchy,
+          ProductCategories/ID,
+          preorder,
+          descendants(
+            $root/ProductCategories,ProductCategoryHierarchy,
+            ID,
+            filter(Name eq 'Car'),
+            keep start)),
+          keep start)
+      )),
       aggregate(Amount with sum as Total))
 
   - Name: aggregation with 1:n hierarchy assignment

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -448,6 +448,10 @@ TestCases:
     FailAt: 24
     Input: $apply=aggregate($count with sum as SalesCount)
 
+  - Name: aggregate - $count with type cast
+    Rule: queryOptions
+    Input: $apply=aggregate(Products/Self.DigitalProduct/$count as Stuff)
+
   - Name: aggregate - topcount
     Rule: queryOptions
     Input: $apply=topcount(2,Amount)

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -569,7 +569,8 @@ TestCases:
           IncludeSelf=true)),
         SalesOrgHierarchy,
         SalesOrganization/ID)),
-      aggregate(Amount with sum as Total))
+      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
+        SalesOrgHierarchy,SalesOrganization/ID,preorder)
 
   - Name: aggregate - filter
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -69,6 +69,7 @@ Constraints:
   actionImport: []
   expressionAlias:
     - Actual
+    - AmountExcl
     - AverageAmount
     - AveragePrice
     - AvgAmt
@@ -107,6 +108,7 @@ Constraints:
     - Tax
     - Total
     - TotalAmount
+    - TotalAmountExcl
     - TotalPlannedRevenue
     - TotalPopulation
     - TotalSales
@@ -202,6 +204,7 @@ Constraints:
     - ID
   primitiveNonKeyProperty:
     - Amount
+    - AmountExcl
     - City
     - Cost
     - CountryCode
@@ -1164,6 +1167,20 @@ TestCases:
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID)),
       filter(Aggregation.excludingdescendants()))
+
+  - Name: restricted hierarchical measure
+    Rule: queryOptions
+    Input: $apply=groupby(
+      (rolluprecursive(
+        $root/SalesOrganizations,
+        SalesOrgHierarchy,
+        SalesOrganization/ID,
+        descendants($root/SalesOrganizations,
+                    SalesOrgHierarchy,
+                    ID, filter(ID eq 'US'), keep start))),
+      compute(case(Aggregation.excludingdescendants():Amount) as AmountExcl)/aggregate(
+        Amount with sum as TotalAmount,
+        AmountExcl with sum as TotalAmountExcl))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -572,18 +572,19 @@ TestCases:
       aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
         SalesOrgHierarchy,SalesOrganization/ID,preorder)
 
-  - Name: aggregate - groupby rollup recursive sub-hierarchy, shortcut
+  - Name: aggregate - groupby rollup recursive sub-hierarchy with filter
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive(
         $root/SalesOrganizations,
         SalesOrgHierarchy,
         SalesOrganization/ID,
-        filter(ID eq 'EMEA'),
-        2)),
+        descendants(filter(ID eq 'EMEA'),2),
+        ancestors(filter(contains(Name, 'Central'))))),
       aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
         SalesOrgHierarchy,SalesOrganization/ID,preorder)
     Expect:
       - preservingTrafos:filter(ID eq 'EMEA')
+      - preservingTrafos:filter(contains(Name, 'Central'))
 
   - Name: aggregate - filter
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -406,9 +406,10 @@ TestCases:
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average as DailyAverage)
 
-  - Name: aggregate - custom aggregate and multiple from
+  - Name: aggregate - custom aggregate and multiple from, missing alias
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time from Product/Name with average as DailyAverage)
+    FailAt: 66
+    Input: $apply=aggregate(Forecast from Time from Product/Name with average)
 
   - Name: aggregate - custom aggregate and from multiple
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -192,6 +192,7 @@ Constraints:
     - isancestor
     - issibling
     - isdescendant
+    - excludingdescendants
     - Rating
     - sqrt
   primitiveFunctionImport: []
@@ -1161,10 +1162,8 @@ TestCases:
 
   - Name: traverserecursive
     Rule: queryOptions
-    Input: $apply=groupby((traverserecursive($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
-      preorder(Name))),identity)
-    Expect:
-      - traverseOrder:preorder(Name)
+    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID)),
+      filter(Aggregation.excludingdescendants()))
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -341,12 +341,6 @@ TestCases:
     Expect:
       - aggregatableFactor:Product/Name # is also an aggrPathPrimitive
 
-  - Name: aggregate - custom aggregation method with type cast
-    Rule: queryOptions
-    Input: $apply=aggregate(Products/Self.DigitalProduct with Custom.discount as Stuff)
-    Expect:
-      - aggrPathPrefix:Products/Self.DigitalProduct # is also an aggrCollPath
-
   - Name: aggregate - custom aggregation method with complex property
     Rule: queryOptions
     Input: $apply=aggregate(Product/ShipTo with Custom.TSP as Stuff)
@@ -414,18 +408,6 @@ TestCases:
     Expect:
       - aggrPathPrefix:Sales
 
-  - Name: aggregate - custom aggregate reached via type cast
-    Rule: queryOptions
-    Input: $apply=aggregate(Products/Self.DigitalProduct/Forecast)
-    Expect:
-      - aggrPathPrefix:Products/Self.DigitalProduct
-
-  - Name: aggregate - custom aggregate reached via type cast only
-    Rule: queryOptions
-    Input: $apply=aggregate(Self.DigitalProduct/Forecast)
-    Expect:
-      - aggrCastPath:Self.DigitalProduct
-
   - Name: aggregate - custom aggregate and from
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average as DailyAverage)
@@ -469,12 +451,6 @@ TestCases:
   - Name: aggregate - $count with type cast
     Rule: queryOptions
     Input: $apply=aggregate(Products/Self.DigitalProduct/$count as Stuff)
-    Expect:
-      - aggrCollPath:Products/Self.DigitalProduct
-
-  - Name: aggregate - $count with type cast
-    Rule: queryOptions
-    Input: $apply=aggregate(Self.DigitalProduct/$count as Stuff)
 
   - Name: aggregate - topcount
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -554,34 +554,22 @@ TestCases:
 
   - Name: aggregate - groupby rollup recursive hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
-      SalesOrgCount))
+    Input: $apply=groupby((rolluprecursive(ID)),aggregate($count as
+      SalesOrgCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: aggregate - groupby rollup recursive sub-hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rolluprecursive(
-        $root/SalesOrganizations/$filter(Aggregation.isdescendant(
-          HierarchyNodes=$root/SalesOrganizations,
-          HierarchyQualifier='SalesOrgHierarchy',
-          Node=ID,
-          Ancestor='EMEA',
-          MaxDistance=2,
-          IncludeSelf=true)),
-        SalesOrgHierarchy,
-        SalesOrganization/ID)),
-      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
-        SalesOrgHierarchy,SalesOrganization/ID,preorder)
+    Input: $apply=groupby((rolluprecursive(SalesOrganization/ID,descendants(ID,filter(ID eq 'EMEA')))),
+      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse(SalesOrganization/ID,
+      preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: aggregate - groupby rollup recursive sub-hierarchy with filter
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive(
-        $root/SalesOrganizations,
-        SalesOrgHierarchy,
         SalesOrganization/ID,
-        descendants(filter(ID eq 'EMEA'),2),
-        ancestors(filter(contains(Name, 'Central'))))),
-      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
-        SalesOrgHierarchy,SalesOrganization/ID,preorder)
+        descendants(ID,filter(ID eq 'EMEA'),2,keep start)/ancestors(ID,filter(contains(Name, 'Central')),keep start))),
+      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse(SalesOrganization/ID,
+      preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
     Expect:
       - preservingTrafos:filter(ID eq 'EMEA')
       - preservingTrafos:filter(contains(Name, 'Central'))
@@ -853,50 +841,50 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors with forbidden node property path
     Rule: queryOptions
-    FailAt: 65
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,Sales(4711)/ID,identity)
+    FailAt: 25
+    Input: $apply=ancestors(ID,Sales(4711)/ID,identity)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - ancestors of search result
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,search(East)/top(3))
+    Input: $apply=ancestors(ID,search(East)/top(3))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
     Expect:
       - preservingTrafos:search(East)/top(3)
 
   - Name: hierarchy transformations - ancestors
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
-      contains(Name,'Central')))
+    Input: $apply=ancestors(ID,filter(contains(Name,'East') or
+      contains(Name,'Central')))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - ancestors max distance
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
-      contains(Name,'Central')), 2)
+    Input: $apply=ancestors(ID,filter(contains(Name,'East') or
+      contains(Name,'Central')), 2)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - ancestors hierarchy directory
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrgHierarchies('DEFAULT')/Nodes,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
-      contains(Name,'Central')), keep start)
+    Input: $apply=ancestors(ID,filter(contains(Name,'East') or
+      contains(Name,'Central')), keep start)&$hierarchy=$root/SalesOrgHierarchies('DEFAULT')/Nodes,SalesOrgHierarchy
 
   - Name: hierarchy transformations - ancestors processing non-hierarchical input set; node values via navigation property
     Rule: odataRelativeUri
-    Input: Sales?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
-      filter(contains(SalesOrganization/Name,'East') or contains(SalesOrganization/Name,'Central')), 2, keep start)
+    Input: Sales?$apply=ancestors(SalesOrganization/ID,filter(contains(SalesOrganization/Name,'East') or
+      contains(SalesOrganization/Name,'Central')), 2, keep start)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - descendants
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'))
+    Input: $apply=descendants(ID,filter(Name eq 'US'))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - descendants max distance
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'), 3)
+    Input: $apply=descendants(ID,filter(Name eq 'US'), 3)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - descendants keep start
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),3,keep start)
+    Input: $apply=descendants(ID,filter(Name eq 'US'),3,keep start)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: hierarchy transformations - traverse
     Rule: queryOptions
-    Input: $apply=traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
+    Input: $apply=traverse(ID,preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: distinct values - no aggregate
     Rule: odataRelativeUri
@@ -1139,15 +1127,15 @@ TestCases:
 
   - Name: transformation sequences - sub-hierarchy selection
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),keep
-      start)/ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East')),keep
-      start)/traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
+    Input: $apply=descendants(ID,filter(Name eq 'US'),keep
+      start)/ancestors(ID,filter(contains(Name,'East')),keep
+      start)/traverse(ID,preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),
-      aggregate(Sales/$count as PaperSalesCount))
+      'Paper'))/groupby((rolluprecursive(ID)),
+      aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -448,10 +448,6 @@ TestCases:
     FailAt: 24
     Input: $apply=aggregate($count with sum as SalesCount)
 
-  - Name: aggregate - $count with type cast
-    Rule: queryOptions
-    Input: $apply=aggregate(Products/Self.DigitalProduct/$count as Stuff)
-
   - Name: aggregate - topcount
     Rule: queryOptions
     Input: $apply=topcount(2,Amount)

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -341,6 +341,12 @@ TestCases:
     Expect:
       - aggregatableFactor:Product/Name # is also an aggrPathPrimitive
 
+  - Name: aggregate - custom aggregation method with type cast
+    Rule: queryOptions
+    Input: $apply=aggregate(Products/Self.DigitalProduct with Custom.discount as Stuff)
+    Expect:
+      - aggrPathPrefix:Products/Self.DigitalProduct # is also an aggrCollPath
+
   - Name: aggregate - custom aggregation method with complex property
     Rule: queryOptions
     Input: $apply=aggregate(Product/ShipTo with Custom.TSP as Stuff)
@@ -408,6 +414,18 @@ TestCases:
     Expect:
       - aggrPathPrefix:Sales
 
+  - Name: aggregate - custom aggregate reached via type cast
+    Rule: queryOptions
+    Input: $apply=aggregate(Products/Self.DigitalProduct/Forecast)
+    Expect:
+      - aggrPathPrefix:Products/Self.DigitalProduct
+
+  - Name: aggregate - custom aggregate reached via type cast only
+    Rule: queryOptions
+    Input: $apply=aggregate(Self.DigitalProduct/Forecast)
+    Expect:
+      - aggrCastPath:Self.DigitalProduct
+
   - Name: aggregate - custom aggregate and from
     Rule: queryOptions
     Input: $apply=aggregate(Forecast from Time with average as DailyAverage)
@@ -451,6 +469,12 @@ TestCases:
   - Name: aggregate - $count with type cast
     Rule: queryOptions
     Input: $apply=aggregate(Products/Self.DigitalProduct/$count as Stuff)
+    Expect:
+      - aggrCollPath:Products/Self.DigitalProduct
+
+  - Name: aggregate - $count with type cast
+    Rule: queryOptions
+    Input: $apply=aggregate(Self.DigitalProduct/$count as Stuff)
 
   - Name: aggregate - topcount
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -204,7 +204,7 @@ Constraints:
     - ID
   primitiveNonKeyProperty:
     - Amount
-    - AmountExcl
+    - AmountExcl # dynamic
     - City
     - Cost
     - CountryCode

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -420,10 +420,11 @@ TestCases:
 
   - Name: aggregate - custom aggregate, with, custom aggregate again
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time with average from Product/Name)
+    Input: $apply=aggregate(Forecast from Time with average from Product/Name as DailyAverage)
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
+    FailAt: 35
     Input: $apply=aggregate(Forecast from Time)
 
   - Name: aggregate - path with key segment

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -847,8 +847,8 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors with forbidden node property path
     Rule: queryOptions
-    FailAt: 68
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,Sales(4711)/ID,identity)
+    FailAt: 65
+    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,Sales(4711)/ID,identity)
 
   - Name: hierarchy transformations - ancestors of search result
     Rule: queryOptions
@@ -873,7 +873,8 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors processing non-hierarchical input set; node values via navigation property
     Rule: odataRelativeUri
-    Input: Sales?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,filter(contains(SalesOrganization/Name,'East') or
+    Input: Sales?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
+      filter(contains(SalesOrganization/Name,'East') or
       contains(SalesOrganization/Name,'Central')), 2, keep start)
 
   - Name: hierarchy transformations - descendants

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -550,6 +550,20 @@ TestCases:
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
       SalesOrgCount))
 
+  - Name: aggregate - groupby rollup recursive sub-hierarchy
+    Rule: queryOptions
+    Input: $apply=groupby((rolluprecursive(
+        $root/SalesOrganizations/$filter(Aggregation.isdescendant(
+          HierarchyNodes=$root/SalesOrganizations,
+          HierarchyQualifier='SalesOrgHierarchy',
+          Node=ID,
+          Ancestor='EMEA',
+          MaxDistance=2,
+          IncludeSelf=true)),
+        SalesOrgHierarchy,
+        SalesOrganization/ID)),
+      aggregate(Amount with sum as Total))
+
   - Name: aggregate - filter
     Rule: queryOptions
     Input: $apply=filter(Amount gt 3)

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1144,7 +1144,8 @@ TestCases:
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID,
       ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,
-      descendants($root/SalesRepresentatives,SalesRepHierarchy,ID,filter(ID eq 'DE-MA'),keep start),keep start))),
+        descendants($root/SalesRepresentatives,SalesRepHierarchy,ID,filter(ID eq 'DE-MA'),keep start),
+      keep start))),
       aggregate(Amount with sum as Total))
 
   - Name: aggregation with 1:n hierarchy assignment

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -392,6 +392,10 @@ TestCases:
     FailAt: 24
     Input: $apply=aggregate(Amount from Time with average as DailyAverage)
 
+  - Name: aggregate - $count from
+    Rule: queryOptions
+    Input: $apply=aggregate(Sales/$count from Time with average as DailyAverage)
+
   - Name: aggregate - custom aggregate reached via path
     Rule: queryOptions
     Input: $apply=aggregate(Sales/Forecast)
@@ -416,11 +420,11 @@ TestCases:
 
   - Name: aggregate - custom aggregate, with, custom aggregate again
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time with average from Product/Name as DailyAverage)
+    Input: $apply=aggregate(Forecast from Time with average from Product/Name)
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    Input: $apply=aggregate(Forecast from Time as Stuff)
+    Input: $apply=aggregate(Forecast from Time)
 
   - Name: aggregate - path with key segment
     Rule: queryOptions
@@ -699,9 +703,9 @@ TestCases:
       $apply=compute(Amount div $these/aggregate(p:Amount with sum from Time
       with average) as RelativeAmount)
 
-  - Name: aggregate function - across input set with $count
+  - Name: aggregate function - across input set with $count and from
     Rule: queryOptions
-    Input: $apply=compute($these/aggregate(p:$count) as SalesCount)
+    Input: $apply=compute($these/aggregate(p:$count from Product with max) as SalesCount)
 
   - Name: aggregate function - across input set with $count
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -572,6 +572,19 @@ TestCases:
       aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
         SalesOrgHierarchy,SalesOrganization/ID,preorder)
 
+  - Name: aggregate - groupby rollup recursive sub-hierarchy, shortcut
+    Rule: queryOptions
+    Input: $apply=groupby((rolluprecursive(
+        $root/SalesOrganizations,
+        SalesOrgHierarchy,
+        SalesOrganization/ID,
+        filter(ID eq 'EMEA'),
+        2)),
+      aggregate(Amount with sum as Total))/orderby(SalesOrganization/Name)/traverse($root/SalesOrganizations,
+        SalesOrgHierarchy,SalesOrganization/ID,preorder)
+    Expect:
+      - preservingTrafos:filter(ID eq 'EMEA')
+
   - Name: aggregate - filter
     Rule: queryOptions
     Input: $apply=filter(Amount gt 3)

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1162,9 +1162,9 @@ TestCases:
   - Name: traverserecursive
     Rule: queryOptions
     Input: $apply=groupby((traverserecursive($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
-      preorderby(Name))),identity)
+      preorder(Name))),identity)
     Expect:
-      - traverseOrder:preorderby(Name)
+      - traverseOrder:preorder(Name)
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1140,12 +1140,19 @@ TestCases:
       'Paper'))/groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),
       aggregate(Sales/$count as PaperSalesCount))
 
-  - Name: two hierarchies in one transformation sequence 
+  - Name: two hierarchies in one transformation sequence
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID,
       ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,
       descendants($root/SalesRepresentatives,SalesRepHierarchy,ID,filter(ID eq 'DE-MA'),keep start),keep start))),
       aggregate(Amount with sum as Total))
+
+  - Name: aggregation with 1:n hierarchy assignment
+    Rule: queryOptions
+    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,Suppliers/SalesOrganization/ID)),
+      aggregate(Amount with sum as Total))
+    Expect:
+      - recHierRollupPPath:Suppliers/SalesOrganization/ID
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -195,7 +195,7 @@ Constraints:
     - isancestor
     - issibling
     - isdescendant
-    - excludingdescendants
+    - rollupnode
     - Rating
     - sqrt
   primitiveFunctionImport: []
@@ -1241,7 +1241,7 @@ TestCases:
   - Name: traverserecursive
     Rule: queryOptions
     Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID)),
-      filter(Aggregation.excludingdescendants()))
+      filter(SalesOrganization eq Aggregation.rollupnode()))
 
   - Name: restricted hierarchical measure
     Rule: queryOptions
@@ -1253,7 +1253,7 @@ TestCases:
         descendants($root/SalesOrganizations,
                     SalesOrgHierarchy,
                     ID, filter(ID eq 'US'), keep start))),
-      compute(case(Aggregation.excludingdescendants():Amount) as AmountExcl)/aggregate(
+      compute(case(SalesOrganization eq Aggregation.rollupnode():Amount) as AmountExcl)/aggregate(
         Amount with sum as TotalAmount,
         AmountExcl with sum as TotalAmountExcl))
 

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -425,8 +425,7 @@ TestCases:
 
   - Name: aggregate - custom aggregate and from without with
     Rule: queryOptions
-    FailAt: 35
-    Input: $apply=aggregate(Forecast from Time)
+    Input: $apply=aggregate(Forecast from Time as DailyAverage)
 
   - Name: aggregate - path with key segment
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -112,6 +112,7 @@ Constraints:
     - TotalPlannedRevenue
     - TotalPopulation
     - TotalSales
+    - WeightedAmount
     - WeekDay
   complexAnnotationInQuery:
     - '@Core.GeometryFeature'
@@ -198,6 +199,7 @@ Constraints:
     - rollupnode
     - Rating
     - sqrt
+    - Weight
   primitiveFunctionImport: []
   primitiveKeyProperty:
     - Code
@@ -232,6 +234,7 @@ Constraints:
     - Street
     - TaxRate
     - Total # dynamic
+    - WeightedAmount # dynamic
     - Year
   streamProperty:
     - Image
@@ -1230,6 +1233,17 @@ TestCases:
           keep start)
       )),
       aggregate(Amount with sum as Total))
+
+  - Name: multi-parent hierarchy with weighted edges
+     (ns.SalesOrganization@Aggregation.RecursiveHierarchy#SalesOrgHierarchy/ParentPropertyPath = Edges/Parent)
+    Rule: queryOptions
+    Input: $apply=groupby(
+      (rolluprecursive(
+        $root/SalesOrganizations,
+        SalesOrgHierarchy,
+        SalesOrganization/ID)),
+      compute(Amount mul Self.Weight(Ancestor=Aggregation.rollupnode()) as
+        WeightedAmount)/aggregate(WeightedAmount with sum as TotalAmount))
 
   - Name: aggregation with 1:n hierarchy assignment
     Rule: queryOptions


### PR DESCRIPTION
* hierarchical transformations can operate on a filtered hierarchy
* collection-valued node property paths in hierarchical transformations (for example, sales transactions that are associated with multiple sales organizations)