### PR TITLE
$hierarchy

### DIFF
--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -89,6 +89,7 @@ applyTrafo = aggregateTrafo
            / nestTrafo
            / outerjoinTrafo
            / preservingTrafo
+           / hierarchyTrafo
 preservingTrafo = bottomcountTrafo
                 / bottompercentTrafo
                 / bottomsumTrafo
@@ -101,7 +102,6 @@ preservingTrafo = bottomcountTrafo
                 / topcountTrafo
                 / toppercentTrafo
                 / topsumTrafo
-                / hierarchyTrafo
                 / customFunction ; custom functions could be preserving, hence are allowed in preservingTrafos
 hierarchyTrafo  = ancestorsTrafo
                 / descendantsTrafo
@@ -234,7 +234,10 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS optionalHierarchyTrafos BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN BWS
+                    ( recHierPropertyPath [ BWS COMMA BWS optionalHierarchyTrafos ]
+                    / optionalHierarchyTrafos )
+                    BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -107,7 +107,7 @@ hierarchyTrafo  = ancestorsTrafo
                 / descendantsTrafo
                 / traverseTrafo
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
-optionalHierarchyTrafos = [ hierarchyTrafo *( "/" hierarchyTrafo ) ]
+hierarchyTrafos  = [ hierarchyTrafo *( "/" hierarchyTrafo ) ]
 
 aggregateTrafo  = %s"aggregate" OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
 aggregateItem   = %s"$count" asAlias 
@@ -220,8 +220,8 @@ traverseTrafo   = %s"traverse" OPEN
 hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ recHierReference
 recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA
-                   BWS recHierQualifier BWS COMMA
-                   BWS recHierPropertyPath
+                   BWS recHierQualifier
+                   [ BWS COMMA BWS recHierPropertyPath ]
 recHierQualifier = odataIdentifier
 recHierPropertyPath = *( ( complexProperty / entityNavigationProperty ) "/" ) primitiveProperty
 
@@ -235,8 +235,8 @@ groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
 rollupRecursive   = %s"rolluprecursive" OPEN BWS
-                    ( recHierPropertyPath [ BWS COMMA BWS optionalHierarchyTrafos ]
-                    / optionalHierarchyTrafos )
+                    ( recHierPropertyPath [ BWS COMMA BWS hierarchyTrafos ]
+                    / [ hierarchyTrafos ] )
                     BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -107,7 +107,7 @@ hierarchyTrafo  = ancestorsTrafo
                 / descendantsTrafo
                 / traverseTrafo
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
-hierarchyTrafos  = [ hierarchyTrafo *( "/" hierarchyTrafo ) ]
+hierarchyTrafos  = hierarchyTrafo *( "/" hierarchyTrafo )
 
 aggregateTrafo  = %s"aggregate" OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
 aggregateItem   = %s"$count" asAlias 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -106,6 +106,7 @@ preservingTrafo = bottomcountTrafo
 hierarchyTrafo  = ancestorsTrafo
                 / descendantsTrafo
                 / traverseTrafo
+                / customFunction ; custom functions could be hierarchical, hence are allowed in hierarchyTrafos
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
 hierarchyTrafos  = hierarchyTrafo *( "/" hierarchyTrafo )
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -235,10 +235,7 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS
-                    ( recHierPropertyPath [ BWS COMMA BWS hierarchyTrafos ]
-                    / [ hierarchyTrafos ] )
-                    BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN [ BWS hierarchyTrafos ] BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -63,9 +63,9 @@
 ; 1. New alternatives for OData ABNF Construction Rules
 ;------------------------------------------------------------------------------
 
-systemQueryOption =/ apply
+systemQueryOption =/ apply / hierarchy
 
-expandOption =/ apply
+expandOption =/ apply / hierarchy
 
 boolMethodCallExpr =/ isdefinedExpr
 
@@ -82,15 +82,12 @@ collectionPathExpr =/ "/" aggregateMethodCallExpr
 apply      = ( "$apply" / "apply" ) EQ applyExpr
 applyExpr  = applyTrafo *( "/" applyTrafo )
 applyTrafo = aggregateTrafo
-           / ancestorsTrafo
            / computeTrafo
            / concatTrafo
-           / descendantsTrafo
            / groupbyTrafo
            / joinTrafo
            / nestTrafo
            / outerjoinTrafo
-           / traverseTrafo
            / preservingTrafo
 preservingTrafo = bottomcountTrafo
                 / bottompercentTrafo
@@ -104,8 +101,13 @@ preservingTrafo = bottomcountTrafo
                 / topcountTrafo
                 / toppercentTrafo
                 / topsumTrafo
+                / hierarchyTrafo
                 / customFunction ; custom functions could be preserving, hence are allowed in preservingTrafos
+hierarchyTrafo  = ancestorsTrafo
+                / descendantsTrafo
+                / traverseTrafo
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
+optionalHierarchyTrafos = [ hierarchyTrafo *( "/" hierarchyTrafo ) ]
 
 aggregateTrafo  = %s"aggregate" OPEN BWS aggregateItem *( BWS COMMA BWS aggregateItem ) BWS CLOSE
 aggregateItem   = %s"$count" asAlias 
@@ -200,24 +202,22 @@ joinProperty    = ( complexColProperty
                   )
 
 ancestorsTrafo  = %s"ancestors" OPEN 
-                  BWS recHierReference BWS 
-                  COMMA BWS preservingTrafos BWS
+                  BWS preservingTrafos BWS
                   [ COMMA BWS 1*DIGIT BWS ]
                   [ COMMA BWS %s"keep start" BWS ]
                   CLOSE
 
 descendantsTrafo = %s"descendants" OPEN 
-                 BWS recHierReference BWS 
-                 COMMA BWS preservingTrafos BWS
+                 BWS preservingTrafos BWS
                  [ COMMA BWS 1*DIGIT BWS ]
                  [ COMMA BWS %s"keep start" BWS ]
                  CLOSE
 
 traverseTrafo   = %s"traverse" OPEN 
-                  BWS recHierReference BWS 
-                  COMMA BWS ( %s"preorder" / %s"postorder" ) BWS 
+                  BWS ( %s"preorder" / %s"postorder" ) BWS 
                   CLOSE 
 
+hierarchy        = ( "$hierarchy" / "hierarchy" ) EQ recHierReference
 recHierReference = rootExpr ; must have type Collection(Edm.EntityType)
                    BWS COMMA
                    BWS recHierQualifier BWS COMMA
@@ -234,7 +234,7 @@ groupbyList     = OPEN BWS groupbyElement *( BWS COMMA BWS groupbyElement ) BWS 
 groupbyElement  = groupingProperty / rollupLevels / rollupRecursive
 
 rollupLevels      = %s"rollup" OPEN BWS ( rollupUnnamedHier / rollupNamedHier ) BWS CLOSE
-rollupRecursive   = %s"rolluprecursive" OPEN BWS recHierReference BWS CLOSE
+rollupRecursive   = %s"rolluprecursive" OPEN BWS optionalHierarchyTrafos BWS CLOSE
 rollupUnnamedHier = groupingProperty 1*( BWS COMMA BWS groupingProperty )
 rollupNamedHier   = odataIdentifier ; qualifier of Aggregation.LeveledHierarchy annotation
 

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1105,10 +1105,8 @@ TestCases:
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rolluprecursive(SalesOrganization/ID)),
+      'Paper'))/groupby((rolluprecursive()),
       aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
-    Expect:
-      - recHierPropertyPath:SalesOrganization/ID
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -542,8 +542,8 @@ TestCases:
 
   - Name: aggregate - groupby rollup recursive hierarchy
     Rule: queryOptions
-    Input: $apply=groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),aggregate($count as
-      SalesOrgCount))
+    Input: $apply=groupby((rolluprecursive()),aggregate($count as
+      SalesOrgCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: aggregate - filter
     Rule: queryOptions
@@ -812,50 +812,50 @@ TestCases:
 
   - Name: hierarchy transformations - ancestors with forbidden node property path
     Rule: queryOptions
-    FailAt: 65
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,Sales(4711)/ID,identity)
+    FailAt: 22
+    Input: $apply=ancestors(Sales(4711)/ID,identity)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - ancestors of search result
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,search(East)/top(3))
+    Input: $apply=ancestors(search(East)/top(3))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
     Expect:
       - preservingTrafos:search(East)/top(3)
 
   - Name: hierarchy transformations - ancestors
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
-      contains(Name,'Central')))
+    Input: $apply=ancestors(filter(contains(Name,'East') or
+      contains(Name,'Central')))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - ancestors max distance
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
-      contains(Name,'Central')), 2)
+    Input: $apply=ancestors(filter(contains(Name,'East') or
+      contains(Name,'Central')), 2)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - ancestors hierarchy directory
     Rule: queryOptions
-    Input: $apply=ancestors($root/SalesOrgHierarchies('DEFAULT')/Nodes,SalesOrgHierarchy,ID,filter(contains(Name,'East') or
-      contains(Name,'Central')), keep start)
+    Input: $apply=ancestors(filter(contains(Name,'East') or
+      contains(Name,'Central')), keep start)&$hierarchy=$root/SalesOrgHierarchies('DEFAULT')/Nodes,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - ancestors processing non-hierarchical input set; node values via navigation property
     Rule: odataRelativeUri
-    Input: Sales?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID,
-      filter(contains(SalesOrganization/Name,'East') or contains(SalesOrganization/Name,'Central')), 2, keep start)
+    Input: Sales?$apply=ancestors(filter(contains(SalesOrganization/Name,'East') or
+      contains(SalesOrganization/Name,'Central')), 2, keep start)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID
 
   - Name: hierarchy transformations - descendants
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'))
+    Input: $apply=descendants(filter(Name eq 'US'))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - descendants max distance
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'), 3)
+    Input: $apply=descendants(filter(Name eq 'US'), 3)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - descendants keep start
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),3,keep start)
+    Input: $apply=descendants(filter(Name eq 'US'),3,keep start)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: hierarchy transformations - traverse
     Rule: queryOptions
-    Input: $apply=traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
+    Input: $apply=traverse(preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: distinct values - no aggregate
     Rule: odataRelativeUri
@@ -1098,15 +1098,15 @@ TestCases:
 
   - Name: transformation sequences - sub-hierarchy selection
     Rule: queryOptions
-    Input: $apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(Name eq 'US'),keep
-      start)/ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(contains(Name,'East')),keep
-      start)/traverse($root/SalesOrganizations,SalesOrgHierarchy,ID,preorder)
+    Input: $apply=descendants(filter(Name eq 'US'),keep
+      start)/ancestors(filter(contains(Name,'East')),keep
+      start)/traverse(preorder)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rolluprecursive($root/SalesOrganizations,SalesOrgHierarchy,ID)),
-      aggregate(Sales/$count as PaperSalesCount))
+      'Paper'))/groupby((rolluprecursive()),
+      aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1106,10 +1106,9 @@ TestCases:
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
       'Paper'))/groupby((rolluprecursive(SalesOrganization/ID)),
-      aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
+      aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
     Expect:
       - recHierPropertyPath:SalesOrganization/ID
-      - recHierPropertyPath:ID
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -1105,8 +1105,11 @@ TestCases:
   - Name: transformation sequences - aggregation along hierarchy
     Rule: queryOptions
     Input: $apply=transformnested(Sales,filter(Product/Name eq
-      'Paper'))/groupby((rolluprecursive()),
+      'Paper'))/groupby((rolluprecursive(SalesOrganization/ID)),
       aggregate(Sales/$count as PaperSalesCount))&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,ID
+    Expect:
+      - recHierPropertyPath:SalesOrganization/ID
+      - recHierPropertyPath:ID
 
   - Name: aggregate in $expand
     Rule: odataRelativeUri


### PR DESCRIPTION
To simplify the syntax of hierarchical transformations, remove the first three parameters $H,Q,I$ of the hierarchical transformations `ancestors`, `descendants`, `traverse` and of `rolluprecursive` and introduce a new system query option `$hierarchy=`$H,Q,I$. The third parameter $I$ can be omitted if it equals the `@Aggregation.RecursiveHierarchy#Q/NodeProperty`.
* Ensures there is no "switch" in the hierarchy between `descendants` and a subsequent `ancestors`.
* Avoids redundancy (see [this test case](https://github.com/oasis-tcs/odata-abnf/pull/87/files#diff-3af2afb94993cc2070335e9cbcb427da5379f38e2f6c631b753fa01e18a67fe3L1099-L1103))
* Further abbreviations are possible:
  * `$hierarchy=SalesOrgHierarchy` could imply hierarchy collection = requested resource.
  * If there is only one `Aggregation.RecursiveHierarchy` annotation (perhaps even unqualified?) on the requested resource, `$hierarchy` need not be specified at all.

Without the redundancy, it seems justifiable to allow full-blown hierarchical transformations as optional parameters of `rolluprecursive` (#86):
```
SalesOrganizations?$apply=
descendants(filter(ID eq 'US'), keep start)
/groupby(
  (rolluprecursive(ancestors(filter(contains(Name, 'New York')), keep start))),
  aggregate(...)
)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy
```

If the requested entity set is `Sales` instead of `SalesOrganizations`, however, the hierarchical transformations nested in `rolluprecursive` always use the node property path specified in the `RecursiveHierarchy` annotation, regardless of what is specified in the third parameter of the `$hierarchy` option.
```
Sales?$apply=
descendants(filter(SalesOrganization/ID eq 'US'), keep start)
/groupby(
  (rolluprecursive(ancestors(filter(contains(Name, 'New York')), keep start))),
  aggregate(...)
)&$hierarchy=$root/SalesOrganizations,SalesOrgHierarchy,SalesOrganization/ID
```

A similar switch in the node property path happens in connection with `transformnested`.

As an **alternative** to the system query option `$hierarchy`, we could introduce a transformation `hierarchy`$(H,Q,I,T)$ where $T$ is a transformation sequence.