### PR TITLE
$count after single-valued primitive segment

### DIFF
--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -124,8 +124,8 @@ aggregateMethod = %s"sum"
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
 aggregateCount  = %s"$count"
-                / ( [ aggrCastPath "/" ] aggrPropPath / aggrCastPath ) %s"/$count"
-                / [ aggrPathPrefix "/" ] [ aggrCastPath "/" ] primitiveColProperty %s"/$count"
+                / [ aggrCastPath "/" ] aggrPrimPath   %s"/$count"
+                /   ( aggrPathPrefix / aggrCastPath ) %s"/$count"
 aggregateCustom = [ ( aggrPathPrefix / aggrCastPath ) "/" ] customAggregate
 
 asAlias         = RWS %s"as" RWS expressionAlias

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -124,8 +124,9 @@ aggregateMethod = %s"sum"
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
 aggregateCount  = %s"$count"
-                / [ aggrCastPath "/" ] aggrPrimPath   %s"/$count"
-                /   ( aggrPathPrefix / aggrCastPath ) %s"/$count"
+                / [ aggrCastPath "/" ] aggrPrimPath %s"/$count"
+                / ( aggrPathPrefix / aggrCastPath ) %s"/$count"
+
 aggregateCustom = [ ( aggrPathPrefix / aggrCastPath ) "/" ] customAggregate
 
 asAlias         = RWS %s"as" RWS expressionAlias

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -472,6 +472,10 @@ TestCases:
     FailAt: 24
     Input: $apply=aggregate($count with sum as SalesCount)
 
+  - Name: aggregate - $count with primitive property
+    Rule: queryOptions
+    Input: $apply=aggregate(Discounts/$count as SalesCount)
+
   - Name: aggregate - $count with type cast
     Rule: queryOptions
     Input: $apply=aggregate(Products/Self.DigitalProduct/$count as Stuff)
@@ -982,9 +986,8 @@ TestCases:
     Rule: queryOptions
     Input: $apply=groupby((Name),aggregate(Sales/$count as SalesCount))
 
-  - Name: aggregation methods - no $count segment after single-valued
+  - Name: aggregation methods - $count segment after single-valued
     Rule: queryOptions
-    FailAt: 44
     Input: $apply=groupby((Name),aggregate(Sales/Amount/$count as SalesCount))
 
   - Name: aggregation methods - $count segment and sum


### PR DESCRIPTION
[OData-Aggr, section 3.2.1.1], type 3 allows `/$count` after a single-valued primitive segment. This can make a difference, because instances where this segment evaluates to null are not counted.