### PR TITLE
$top and $skip with expressions

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -314,8 +314,8 @@ filter = ( "$filter" / "filter" ) EQ boolCommonExpr
 orderby     = ( "$orderby" / "orderby" ) EQ orderbyItem *( COMMA orderbyItem )
 orderbyItem = commonExpr [ RWS ( "asc" / "desc" ) ]
 
-skip = ( "$skip" / "skip" ) EQ 1*DIGIT
-top  = ( "$top"  / "top"  ) EQ 1*DIGIT
+skip = ( "$skip" / "skip" ) EQ collectionExpr
+top  = ( "$top"  / "top"  ) EQ collectionExpr
 
 index  = ( "$index" / "index" ) EQ [ "-" ] 1*DIGIT
 


### PR DESCRIPTION
Allow `$top` and `$skip` with "collection expressions" defined like here: https://github.com/oasis-tcs/odata-abnf/blob/c7002111720cc456fc1512ebb869528c220327f8/abnf/odata-aggregation-abnf.txt#L188-L189