### PR TITLE
Allow `commonExpr` in aggregate expressions of type 2

### DIFF
--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -171,7 +171,7 @@ aggregatableArith  = [ "-" BWS ] aggregatableTerm *( RWS ( "add" / "sub" ) RWS a
 aggregatableExpr   = aggregatableArith
                    / [ aggrCastPath "/" ] aggrPrimPath
 
-; aggregateFunExpr is analogous to aggregatableExpr but appears in aggregateFunctionExpr and allows inscopeVariableExpr
+; aggregateFun* is analogous to aggregatable* but appears in aggregateFunctionExpr and allows inscopeVariableExpr
 aggregateFunFactor = aggregatableValue
                    / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPrimPath
                    / [ namespace "." ] primitiveFunction OPEN
@@ -182,7 +182,6 @@ aggregateFunParam  = aggregateFunArith
                    / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPropPath
 aggregateFunTerm   = aggregateFunFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregateFunFactor )
 aggregateFunArith  = [ "-" BWS ] aggregateFunTerm *( RWS ( "add" / "sub" ) RWS aggregateFunTerm )
-aggregateFunExpr   = [ aggrCastPath "/" ] aggrPrimPath
 
 aggrPathPrefix     = [ aggrCastPath "/" ] aggrPropPath
 groupingProperty   = [ aggrCastPath "/" ] ( snglPrimPath / snglPropPath )
@@ -291,10 +290,6 @@ curColAggFunctionExpr = aggregatableExpr aggregateWith [ aggregateFrom ]
                       / aggregateCount [ aggregateFrom ]
                       / aggregateCustom [ customFrom ]
 aggregateFunctionExpr = aggregateFunArith aggregateWith [ aggregateFrom ]
-                      / inscopeVariableExpr "/" aggregateFunExpr aggregateWith [ aggregateFrom ]
-                      / inscopeVariableExpr "/" aggrPathPrefix nonprimAggWith [ aggregateFrom ]
-                      / inscopeVariableExpr "/" aggregateCount [ aggregateFrom ]
-                      / inscopeVariableExpr "/" aggregateCustom [ customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -159,29 +159,17 @@ aggregatableValue  = decimalValue / doubleValue / singleValue / sbyteValue
                    / byteValue    / int16Value  / int32Value  / int64Value
                    / duration
 aggregatableFactor = aggregatableValue
-                   / [ aggrCastPath "/" ] snglPrimPath ; arithmetic only with single-valued segments
+                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPrimPath ; arithmetic only with single-valued segments
                    / [ namespace "." ] primitiveFunction OPEN
                      [ BWS parameterName EQ aggregatableParam *( BWS COMMA BWS parameterName EQ aggregatableParam ) ]
                      BWS CLOSE
                    / OPEN BWS aggregatableArith BWS CLOSE
 aggregatableParam  = aggregatableArith
-                   / [ aggrCastPath "/" ] snglPropPath
+                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPropPath
 aggregatableTerm   = aggregatableFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregatableFactor )
 aggregatableArith  = [ "-" BWS ] aggregatableTerm *( RWS ( "add" / "sub" ) RWS aggregatableTerm )
 aggregatableExpr   = aggregatableArith
-                   / [ aggrCastPath "/" ] aggrPrimPath
-
-; aggregateFun* is analogous to aggregatable* but appears in aggregateFunctionExpr and allows inscopeVariableExpr
-aggregateFunFactor = aggregatableValue
-                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPrimPath
-                   / [ namespace "." ] primitiveFunction OPEN
-                     [ BWS parameterName EQ aggregateFunParam *( BWS COMMA BWS parameterName EQ aggregateFunParam ) ]
-                     BWS CLOSE
-                   / OPEN BWS aggregatableArith BWS CLOSE
-aggregateFunParam  = aggregateFunArith
-                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPropPath
-aggregateFunTerm   = aggregateFunFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregateFunFactor )
-aggregateFunArith  = [ "-" BWS ] aggregateFunTerm *( RWS ( "add" / "sub" ) RWS aggregateFunTerm )
+                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] aggrPrimPath
 
 aggrPathPrefix     = [ aggrCastPath "/" ] aggrPropPath
 groupingProperty   = [ aggrCastPath "/" ] ( snglPrimPath / snglPropPath )
@@ -281,15 +269,15 @@ customFunction  = namespace "." ( entityColFunction / complexColFunction / primi
 
 isdefinedExpr = %s"isdefined" OPEN BWS ( firstMemberExpr ) BWS CLOSE
 
-currCollectionExpr    = %s"aggregate" OPEN BWS curColAggFunctionExpr BWS CLOSE
+currCollectionExpr    = %s"aggregate" OPEN BWS aggregateFunctionExpr BWS CLOSE
                       / %s"$count"
-pathCollectionExpr    = %s"aggregate" OPEN BWS lambdaVariableExpr BWS COLON BWS aggregateFunctionExpr BWS CLOSE
+pathCollectionExpr    = %s"aggregate" OPEN BWS lambdaVariableExpr BWS COLON BWS aggrArithFunctionExpr BWS CLOSE
 ; /$count after a navigation path is already allowed as a collectionPathExpr
-curColAggFunctionExpr = aggregatableExpr aggregateWith [ aggregateFrom ]
+aggregateFunctionExpr = aggregatableExpr aggregateWith [ aggregateFrom ]
                       / aggrPathPrefix nonprimAggWith [ aggregateFrom ]
                       / aggregateCount [ aggregateFrom ]
                       / aggregateCustom [ customFrom ]
-aggregateFunctionExpr = aggregateFunArith aggregateWith [ aggregateFrom ]
+aggrArithFunctionExpr = aggregatableArith aggregateWith [ aggregateFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -159,17 +159,32 @@ aggregatableValue  = decimalValue / doubleValue / singleValue / sbyteValue
                    / byteValue    / int16Value  / int32Value  / int64Value
                    / duration
 aggregatableFactor = aggregatableValue
-                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPrimPath ; arithmetic only with single-valued segments
+                   / [ aggrCastPath "/" ] snglPrimPath ; arithmetic only with single-valued segments
                    / [ namespace "." ] primitiveFunction OPEN
                      [ BWS parameterName EQ aggregatableParam *( BWS COMMA BWS parameterName EQ aggregatableParam ) ]
                      BWS CLOSE
                    / OPEN BWS aggregatableArith BWS CLOSE
 aggregatableParam  = aggregatableArith
-                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] snglPropPath
+                   / [ aggrCastPath "/" ] snglPropPath
 aggregatableTerm   = aggregatableFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregatableFactor )
 aggregatableArith  = [ "-" BWS ] aggregatableTerm *( RWS ( "add" / "sub" ) RWS aggregatableTerm )
 aggregatableExpr   = aggregatableArith
-                   / [ inscopeVariableExpr "/" ] [ aggrCastPath "/" ] aggrPrimPath
+                   / [ aggrCastPath "/" ] aggrPrimPath
+
+; aggregateFunExpr is analogous to aggregatableExpr but appears in aggregateFunctionExpr and allows aggregateFunPrefix
+aggregateFunPrefix = ( inscopeVariableExpr / %s"$it" ) "/"
+aggregateFunFactor = aggregatableValue
+                   / [ aggregateFunPrefix ] [ aggrCastPath "/" ] snglPrimPath
+                   / [ namespace "." ] primitiveFunction OPEN
+                     [ BWS parameterName EQ aggregateFunParam *( BWS COMMA BWS parameterName EQ aggregateFunParam ) ]
+                     BWS CLOSE
+                   / OPEN BWS aggregatableArith BWS CLOSE
+aggregateFunParam  = aggregateFunArith
+                   / [ aggregateFunPrefix ] [ aggrCastPath "/" ] snglPropPath
+aggregateFunTerm   = aggregateFunFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregateFunFactor )
+aggregateFunArith  = [ "-" BWS ] aggregateFunTerm *( RWS ( "add" / "sub" ) RWS aggregateFunTerm )
+aggregateFunExpr   = aggregateFunArith 
+                   / [ aggregateFunPrefix ] [ aggrCastPath "/" ] aggrPrimPath
 
 aggrPathPrefix     = [ aggrCastPath "/" ] aggrPropPath
 groupingProperty   = [ aggrCastPath "/" ] ( snglPrimPath / snglPropPath )
@@ -273,11 +288,11 @@ currCollectionExpr    = %s"aggregate" OPEN BWS aggregateFunctionExpr BWS CLOSE
                       / %s"$count"
 pathCollectionExpr    = %s"aggregate" OPEN BWS lambdaVariableExpr BWS COLON BWS aggrArithFunctionExpr BWS CLOSE
 ; /$count after a navigation path is already allowed as a collectionPathExpr
-aggregateFunctionExpr = aggregatableExpr aggregateWith [ aggregateFrom ]
-                      / aggrPathPrefix nonprimAggWith [ aggregateFrom ]
-                      / aggregateCount [ aggregateFrom ]
-                      / aggregateCustom [ customFrom ]
-aggrArithFunctionExpr = aggregatableArith aggregateWith [ aggregateFrom ]
+aggregateFunctionExpr = aggregateFunExpr aggregateWith [ aggregateFrom ]
+                      / [ aggregateFunPrefix ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
+                      / [ aggregateFunPrefix ] aggregateCount [ aggregateFrom ]
+                      / [ aggregateFunPrefix ] aggregateCustom [ customFrom ]
+aggrArithFunctionExpr = aggregateFunArith aggregateWith [ aggregateFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -115,8 +115,8 @@ aggregateExpr    = ( aggrPathPrefix / aggrCastPath ) nonprimAggWith [ aggregateF
                  / aggregatableExpW [ aggregateFrom ] asAlias
                  / aggregateCount [ aggregateFrom ] asAlias
                  / aggregateCustom [ [ customFrom ] asAlias ]
-aggregatableExpW = commonExpr ; resulting in an aggregatable value
-                   aggregateWith
+aggregatableExpr = commonExpr ; resulting in an aggregatable value
+aggregatableExpW = aggregatableExpr aggregateWith
                  / [ aggrCastPath "/" ] aggrPrimPath aggregateWith
 aggrPathPrefix   = [ aggrCastPath "/" ] aggrPropPath
 aggregateWith    = RWS %s"with" RWS aggregateMethod

--- a/abnf/odata-aggregation-abnf.txt
+++ b/abnf/odata-aggregation-abnf.txt
@@ -73,7 +73,7 @@ primitiveProperty =/ customAggregate
 
 firstMemberExpr =/ currCollectionExpr
 
-collectionPathExpr =/ "/" pathCollectionExpr
+collectionPathExpr =/ %s"/aggregate" OPEN BWS aggregateFunctionExpr BWS CLOSE
 
 ;------------------------------------------------------------------------------
 ; 2. System Query Option $apply
@@ -110,25 +110,29 @@ hierarchyTrafo  = ancestorsTrafo
 preservingTrafos = preservingTrafo *( "/" preservingTrafo )
 hierarchyTrafos  = hierarchyTrafo *( "/" hierarchyTrafo )
 
-aggregateTrafo  = %s"aggregate" OPEN BWS aggregateExpr *( BWS COMMA BWS aggregateExpr ) BWS CLOSE
-aggregateExpr   = aggregatableExpr aggregateWith [ aggregateFrom ] asAlias
-                / ( aggrPathPrefix / aggrCastPath ) nonprimAggWith [ aggregateFrom ] asAlias
-                / aggregateCount [ aggregateFrom ] asAlias
-                / aggregateCustom [ [ customFrom ] asAlias ]
-aggregateWith   = RWS %s"with" RWS aggregateMethod
-nonprimAggWith  = RWS %s"with" RWS nonprimAggMethod
-aggregateFrom   = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
-customFrom      = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
-aggregateMethod = %s"sum"
-                / %s"min"
-                / %s"max"
-                / %s"average"
-                / nonprimAggMethod
+aggregateTrafo   = %s"aggregate" OPEN BWS aggregateExpr *( BWS COMMA BWS aggregateExpr ) BWS CLOSE
+aggregateExpr    = ( aggrPathPrefix / aggrCastPath ) nonprimAggWith [ aggregateFrom ] asAlias
+                 / aggregatableExpW [ aggregateFrom ] asAlias
+                 / aggregateCount [ aggregateFrom ] asAlias
+                 / aggregateCustom [ [ customFrom ] asAlias ]
+aggregatableExpW = commonExpr ; resulting in an aggregatable value
+                   aggregateWith
+                 / [ aggrCastPath "/" ] aggrPrimPath aggregateWith
+aggrPathPrefix   = [ aggrCastPath "/" ] aggrPropPath
+aggregateWith    = RWS %s"with" RWS aggregateMethod
+nonprimAggWith   = RWS %s"with" RWS nonprimAggMethod
+aggregateFrom    = RWS %s"from" RWS groupingProperties aggregateWith [ aggregateFrom ]
+customFrom       = RWS %s"from" RWS groupingProperties [ aggregateWith ] [ customFrom ]
+aggregateMethod  = %s"sum"
+                 / %s"min"
+                 / %s"max"
+                 / %s"average"
+                 / nonprimAggMethod
 nonprimAggMethod = %s"countdistinct"
                  / namespace "." odataIdentifier ; custom aggregation methods may work on non-primitive values
-aggregateCount  = %s"$count"
-                / [ aggrCastPath "/" ] aggrPrimPath count
-                / ( aggrPathPrefix / aggrCastPath ) count
+aggregateCount   = %s"$count"
+                 / [ aggrCastPath "/" ] aggrPrimPath count
+                 / ( aggrPathPrefix / aggrCastPath ) count
 
 aggregateCustom = [ ( aggrPathPrefix / aggrCastPath ) "/" ] customAggregate
 
@@ -155,43 +159,12 @@ snglPropPath = ( complexProperty / entityNavigationProperty ) [ [ "/" aggrCastPa
 snglPrimPath = ( complexProperty / entityNavigationProperty )   [ "/" aggrCastPath ] "/" snglPrimPath
              / primitiveProperty / streamProperty
 
-aggregatableValue  = decimalValue / doubleValue / singleValue / sbyteValue
-                   / byteValue    / int16Value  / int32Value  / int64Value
-                   / duration
-aggregatableFactor = aggregatableValue
-                   / [ aggrCastPath "/" ] snglPrimPath ; arithmetic only with single-valued segments
-                   / [ namespace "." ] primitiveFunction OPEN
-                     [ BWS parameterName EQ aggregatableParam *( BWS COMMA BWS parameterName EQ aggregatableParam ) ]
-                     BWS CLOSE
-                   / OPEN BWS aggregatableArith BWS CLOSE
-aggregatableParam  = aggregatableArith
-                   / [ aggrCastPath "/" ] snglPropPath
-aggregatableTerm   = aggregatableFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregatableFactor )
-aggregatableArith  = [ "-" BWS ] aggregatableTerm *( RWS ( "add" / "sub" ) RWS aggregatableTerm )
-aggregatableExpr   = aggregatableArith
-                   / [ aggrCastPath "/" ] aggrPrimPath
-
-; aggregateFunExpr is analogous to aggregatableExpr but appears in aggregateFunctionExpr and allows aggregateFunPrefix
-aggregateFunPrefix = ( inscopeVariableExpr / %s"$it" ) "/"
-aggregateFunFactor = aggregatableValue
-                   / [ aggregateFunPrefix ] [ aggrCastPath "/" ] snglPrimPath
-                   / [ namespace "." ] primitiveFunction OPEN
-                     [ BWS parameterName EQ aggregateFunParam *( BWS COMMA BWS parameterName EQ aggregateFunParam ) ]
-                     BWS CLOSE
-                   / OPEN BWS aggregatableArith BWS CLOSE
-aggregateFunParam  = aggregateFunArith
-                   / [ aggregateFunPrefix ] [ aggrCastPath "/" ] snglPropPath
-aggregateFunTerm   = aggregateFunFactor *( RWS ( "mul" / "div" / "divby" / "mod" ) RWS aggregateFunFactor )
-aggregateFunArith  = [ "-" BWS ] aggregateFunTerm *( RWS ( "add" / "sub" ) RWS aggregateFunTerm )
-aggregateFunExpr   = aggregateFunArith 
-                   / [ aggregateFunPrefix ] [ aggrCastPath "/" ] aggrPrimPath
-
-aggrPathPrefix     = [ aggrCastPath "/" ] aggrPropPath
 groupingProperty   = [ aggrCastPath "/" ] ( snglPrimPath / snglPropPath )
 groupingProperties = groupingProperty *( BWS COMMA BWS groupingProperty )
 
 ; Expressions evaluable on a collection
-collectionExpr  = commonExpr ; but where every firstMemberExpr must be a currCollectionExpr
+collectionExpr     = commonExpr ; but where every firstMemberExpr must be a currCollectionExpr
+currCollectionExpr = %s"$these" collectionPathExpr
 
 computeTrafo    = %s"compute" OPEN BWS computeExpr *( BWS COMMA BWS computeExpr ) BWS CLOSE
 computeExpr     = commonExpr asAlias             
@@ -284,15 +257,10 @@ customFunction  = namespace "." ( entityColFunction / complexColFunction / primi
 
 isdefinedExpr = %s"isdefined" OPEN BWS ( firstMemberExpr ) BWS CLOSE
 
-currCollectionExpr    = %s"aggregate" OPEN BWS aggregateFunctionExpr BWS CLOSE
-                      / %s"$count"
-pathCollectionExpr    = %s"aggregate" OPEN BWS lambdaVariableExpr BWS COLON BWS aggrArithFunctionExpr BWS CLOSE
-; /$count after a navigation path is already allowed as a collectionPathExpr
-aggregateFunctionExpr = aggregateFunExpr aggregateWith [ aggregateFrom ]
-                      / [ aggregateFunPrefix ] aggrPathPrefix nonprimAggWith [ aggregateFrom ]
-                      / [ aggregateFunPrefix ] aggregateCount [ aggregateFrom ]
-                      / [ aggregateFunPrefix ] aggregateCustom [ customFrom ]
-aggrArithFunctionExpr = aggregateFunArith aggregateWith [ aggregateFrom ]
+aggregateFunctionExpr = aggregatableExpW [ aggregateFrom ]
+                      / aggrPathPrefix nonprimAggWith [ aggregateFrom ]
+                      / aggregateCount [ aggregateFrom ]
+                      / aggregateCustom [ customFrom ]
 
 ;------------------------------------------------------------------------------
 ; End of odata-aggregation-abnf

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -859,13 +859,18 @@ TestCases:
 
   - Name: aggregate function - within filter and lambda
     Rule: queryOptions
+    FailAt: 36
     Input: $filter=Products/aggregate(p:p/Sales/Amount with sum) gt 3
+
+  - Name: aggregate function - within filter without lambda
+    Rule: queryOptions
+    Input: $filter=aggregate(Products/Sales/Amount with sum) gt 3
     Expect:
-      - pathCollectionExpr:aggregate(p:p/Sales/Amount with sum)
+      - currCollectionExpr:aggregate(Products/Sales/Amount with sum)
 
   - Name: aggregate function - countdistinct with navigation property
     Rule: queryOptions
-    Input: $filter=Products/aggregate(p:p/Sales with countdistinct) gt 3
+    Input: $filter=aggregate(Products/Sales with countdistinct) gt 3
 
   - Name: aggregate - crossjoin
     Rule: odataRelativeUri

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -264,11 +264,6 @@ TestCases:
       - aggregatableFactor:(Amount sub Cost)
       - aggregatableFactor:TaxRate
 
-  - Name: aggregate - arithmetic expression with forbidden lambda variable
-    Rule: queryOptions
-    FailAt: 18
-    Input: $apply=aggregate(p/Amount mul TaxRate with sum as Tax)
-
   - Name: aggregate - arithmetic expression with literals
     Rule: queryOptions
     Input: $apply=aggregate((TaxRate sub 1) mul 'P1D' with average as Stuff)
@@ -770,14 +765,14 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Sales/aggregate(p:TaxRate mul p/Amount with sum) gt 5
     Expect:
-      - aggregateFunFactor:TaxRate
-      - aggregateFunFactor:p/Amount
+      - aggregatableFactor:TaxRate
+      - aggregatableFactor:p/Amount
 
   - Name: aggregate function - lambda operators
     Rule: queryOptions
     Input: $filter=Products/all(p:p/Sales/any(s:s/Amount gt p/Sales/aggregate(t:t/Amount with average) mul 2))
     Expect:
-      - aggregateFunArith:t/Amount
+      - aggregatableArith:t/Amount
 
   - Name: aggregate function - omit lambda variable only in type 2
     Rule: queryOptions
@@ -792,7 +787,7 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Sales/aggregate(p:Custom.Rating(Article=p/Product) with average) gt 5
     Expect:
-      - aggregateFunParam:p/Product
+      - aggregatableParam:p/Product
 
   - Name: aggregate function - function expression on current collection
     Rule: queryOptions
@@ -867,6 +862,10 @@ TestCases:
     Input: $filter=aggregate(Products/Sales/Amount with sum) gt 3
     Expect:
       - currCollectionExpr:aggregate(Products/Sales/Amount with sum)
+
+  - Name: aggregate function - aggregate within any
+    Rule: queryOptions
+    Input: $filter=Products/any(p:aggregate(p/Sales/Amount with sum) gt 10)
 
   - Name: aggregate function - countdistinct with navigation property
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -265,9 +265,10 @@ TestCases:
     Rule: queryOptions
     Input: $apply=aggregate((TaxRate sub 1) mul 'P1D' with average as Stuff)
 
-#  - Name: aggregate - forbidden arithmetic on collection
-#    Rule: queryOptions
-#    Input: $apply=aggregate(Sales/Amount sub Sales/Cost with sum as TotalAmount)
+  - Name: aggregate - forbidden arithmetic on collection
+    Rule: queryOptions
+    FailAt: 30
+    Input: $apply=aggregate(Sales/Amount sub Sales/Cost with sum as TotalAmount)
 
   - Name: aggregate - arithmetic with $it
     Rule: queryOptions
@@ -278,9 +279,11 @@ TestCases:
     Input: $apply=addnested(Sales,compute(Amount sub Cost as Profit) as
       Profits)/aggregate(Profits/Profit with sum as TotalAmount)
 
-#  - Name: aggregate - forbidden arithmetic
-#    Rule: queryOptions
-#    Input: $apply=aggregate(Amount sub Discounts with sum as TotalAmount)
+  - Name: aggregate - forbidden arithmetic
+    Rule: queryOptions
+    Input: $apply=aggregate(Amount sub Discounts with sum as TotalAmount)
+    Expect:
+      - aggregatableExpr:Amount sub Discounts # but actually it is not
 
   - Name: aggregate - functional expression
     Rule: queryOptions
@@ -759,6 +762,8 @@ TestCases:
   - Name: aggregate function - arithmetic expression
     Rule: queryOptions
     Input: $filter=Sales/aggregate(TaxRate mul $it/Amount with sum) gt 5
+    Expect:
+      - aggregatableExpr:TaxRate mul $it/Amount
 
   - Name: aggregate function - $compute
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -773,6 +773,13 @@ TestCases:
       - aggregateFunFactor:TaxRate
       - aggregateFunFactor:p/Amount
 
+  - Name: aggregate function - compute with $it
+    Rule: queryOptions
+    Input: $compute=aggregate($it/Sales/Amount with sum) as Total
+    Expect:
+      - aggregateFunPrefix:$it/
+      - aggrPrimPath:Sales/Amount
+
   - Name: aggregate function - lambda operators
     Rule: queryOptions
     Input: $filter=Products/all(p:p/Sales/any(s:s/Amount gt p/Sales/aggregate(t:t/Amount with average) mul 2))

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -179,7 +179,6 @@ Constraints:
   lambdaVariableExpr:
     - p
     - s
-    - t
   namespacePart:
     - Aggregation
     - Core
@@ -761,9 +760,9 @@ TestCases:
 
   - Name: aggregate function - arithmetic expression
     Rule: queryOptions
-    Input: $filter=Sales/aggregate(TaxRate mul $it/Amount with sum) gt 5
+    Input: $filter=Sales/aggregate($it/TaxRate mul Amount with sum) gt 5
     Expect:
-      - aggregatableExpr:TaxRate mul $it/Amount
+      - aggregatableExpr:$it/TaxRate mul Amount
 
   - Name: aggregate function - $compute
     Rule: queryOptions
@@ -846,11 +845,12 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Products/aggregate(Sales/Amount with sum) gt 3
 
-  - Name: aggregate function - within filter on current collection
-    Rule: queryOptions
-    Input: $filter=$these/aggregate(Products/Sales/Amount with sum) gt 3
+  - Name: aggregate function - within filter within groupby
+    Rule: odataRelativeUri
+    Input: Products?$apply=groupby((Category),
+      filter($these/aggregate(Sales/Amount with sum) gt 3))
     Expect:
-      - currCollectionExpr:$these/aggregate(Products/Sales/Amount with sum)
+      - currCollectionExpr:$these/aggregate(Sales/Amount with sum)
 
   - Name: aggregate function - aggregate within any
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -260,35 +260,27 @@ TestCases:
   - Name: aggregate - arithmetic expression
     Rule: queryOptions
     Input: $apply=aggregate((Amount sub Cost) mul TaxRate with sum as Tax)
-    Expect:
-      - aggregatableFactor:(Amount sub Cost)
-      - aggregatableFactor:TaxRate
 
   - Name: aggregate - arithmetic expression with literals
     Rule: queryOptions
     Input: $apply=aggregate((TaxRate sub 1) mul 'P1D' with average as Stuff)
 
-  - Name: aggregate - forbidden arithmetic on collection
-    Rule: queryOptions
-    FailAt: 30
-    Input: $apply=aggregate(Sales/Amount sub Sales/Cost with sum as TotalAmount)
+#  - Name: aggregate - forbidden arithmetic on collection
+#    Rule: queryOptions
+#    Input: $apply=aggregate(Sales/Amount sub Sales/Cost with sum as TotalAmount)
 
-  - Name: aggregate - forbidden arithmetic with $it
+  - Name: aggregate - arithmetic with $it
     Rule: queryOptions
-    FailAt: 28
     Input: $apply=aggregate(Amount sub $it/Cost with sum as TotalAmount)
 
   - Name: aggregate - allowed arithmetic on collection
     Rule: queryOptions
     Input: $apply=addnested(Sales,compute(Amount sub Cost as Profit) as
       Profits)/aggregate(Profits/Profit with sum as TotalAmount)
-    Expect:
-      - aggregatableExpr:Profits/Profit
 
-  - Name: aggregate - forbidden arithmetic
-    Rule: queryOptions
-    FailAt: 37
-    Input: $apply=aggregate(Amount sub Discounts with sum as TotalAmount)
+#  - Name: aggregate - forbidden arithmetic
+#    Rule: queryOptions
+#    Input: $apply=aggregate(Amount sub Discounts with sum as TotalAmount)
 
   - Name: aggregate - functional expression
     Rule: queryOptions
@@ -327,13 +319,14 @@ TestCases:
 
   - Name: aggregate - no expression after path - this feature from CS02 has been removed
     Rule: queryOptions
-    FailAt: 22
+    FailAt: 29
     Input: $apply=aggregate(Sales(Amount mul Product/TaxRate with sum as Tax))
 
   - Name: aggregate - aggregate annotations
     Rule: queryOptions
-    FailAt: 22 # no term casts in data aggregation paths
     Input: $apply=aggregate(Price/@Measures.ISOCurrency with min as MinCurrency)
+    Expect:
+      - annotationExpr:@Measures.ISOCurrency # no term casts in data aggregation paths
 
   - Name: aggregate - alias - context URL
     Rule: odataRelativeUri
@@ -354,8 +347,6 @@ TestCases:
   - Name: aggregate - custom aggregation method
     Rule: queryOptions
     Input: $apply=aggregate(Product/Name with Custom.concat as ProductNames)
-    Expect:
-      - aggregatableFactor:Product/Name
 
   - Name: aggregate - custom aggregation method with type cast
     Rule: queryOptions
@@ -388,11 +379,6 @@ TestCases:
   - Name: aggregate - countdistinct with navigation property
     Rule: queryOptions
     Input: $apply=aggregate(Product with countdistinct as DistinctProducts)
-
-  - Name: aggregate - forbidden sum with navigation property
-    Rule: queryOptions
-    FailAt: 33
-    Input: $apply=aggregate(Product with sum as Stuff)
 
   - Name: aggregate - from
     Rule: queryOptions
@@ -481,7 +467,6 @@ TestCases:
 
   - Name: aggregate - path with key segment
     Rule: queryOptions
-    FailAt: 34
     Input: $apply=aggregate(Product/SalesPlan('2015')/PlannedRevenue with sum as
       TotalPlannedRevenue)
 
@@ -526,9 +511,9 @@ TestCases:
 
   - Name: aggregate - topcount with $count
     Rule: queryOptions
-    Input: $apply=topcount($count div 10,Amount)
+    Input: $apply=topcount($these/$count div 10,Amount)
     Expect:
-      - currCollectionExpr:$count
+      - currCollectionExpr:$these/$count
 
   - Name: aggregate - topsum
     Rule: queryOptions
@@ -766,128 +751,109 @@ TestCases:
     Expect:
       - collectionPathExpr:/$count
 
+  - Name: aggregate function - prefix required
+    Rule: queryOptions
+    FailAt: 17
+    Input: $filter=aggregate(Amount with sum) gt 5
+
   - Name: aggregate function - arithmetic expression
     Rule: queryOptions
-    Input: $filter=Sales/aggregate(p:TaxRate mul p/Amount with sum) gt 5
-    Expect:
-      - aggregateFunFactor:TaxRate
-      - aggregateFunFactor:p/Amount
+    Input: $filter=Sales/aggregate(TaxRate mul $it/Amount with sum) gt 5
 
-  - Name: aggregate function - compute with $it
+  - Name: aggregate function - $compute
     Rule: queryOptions
-    Input: $compute=aggregate($it/Sales/Amount with sum) as Total
-    Expect:
-      - aggregateFunPrefix:$it/
-      - aggrPrimPath:Sales/Amount
+    Input: $compute=Sales/aggregate(Amount with sum) as Total
 
   - Name: aggregate function - lambda operators
     Rule: queryOptions
-    Input: $filter=Products/all(p:p/Sales/any(s:s/Amount gt p/Sales/aggregate(t:t/Amount with average) mul 2))
-    Expect:
-      - aggregateFunArith:t/Amount
-
-  - Name: aggregate function - omit lambda variable only in type 2
-    Rule: queryOptions
-    FailAt: 31
-    Input: $filter=Sales/aggregate(p:Sales/Amount with sum) gt 5
+    Input: $filter=Products/all(p:p/Sales/any(s:s/Amount gt p/Sales/aggregate(Amount with average) mul 2))
 
   - Name: aggregate function after function
     Rule: commonExpr
-    Input: Self.TopProduct()/Sales/aggregate(p:p/Amount with sum)
+    Input: Self.TopProduct()/Sales/aggregate(Amount with sum)
 
   - Name: aggregate function - function expression
     Rule: queryOptions
-    Input: $filter=Sales/aggregate(p:Custom.Rating(Article=p/Product) with average) gt 5
-    Expect:
-      - aggregateFunParam:p/Product
+    Input: $filter=Sales/aggregate(Custom.Rating(Article=Product) with average) gt 5
 
   - Name: aggregate function - function expression on current collection
     Rule: queryOptions
-    Input: $filter=aggregate(Custom.Rating(Article=Product) with average) gt 5
-    Expect:
-      - aggregateFunParam:Product
+    Input: $filter=$these/aggregate(Custom.Rating(Article=Product) with average) gt 5
 
   - Name: aggregate function - after grouping
     Rule: queryOptions
     Input: $apply=groupby((Customer),aggregate(Amount with sum as
-      CustomerAmount))/compute(CustomerAmount div aggregate(CustomerAmount with
+      CustomerAmount))/compute(CustomerAmount div $these/aggregate(CustomerAmount with
       sum) as RevenueContribution)
 
   - Name: aggregate function - within a group
     Rule: queryOptions
     Input: $apply=groupby((Customer,Year),aggregate(Amount with sum as
       CustomerYearAmount))/groupby((Customer),compute(CustomerYearAmount div
-      aggregate(CustomerYearAmount with sum) as RevenueTrend))
+      $these/aggregate(CustomerYearAmount with sum) as RevenueTrend))
 
   - Name: aggregate function - across input set
     Rule: queryOptions
-    Input: $apply=compute(Amount div aggregate(Amount with average) as
+    Input: $apply=compute(Amount div $these/aggregate(Amount with average) as
       RelativeOrderSize)
 
   - Name: aggregate function - across input set with custom aggregate
     Rule: queryOptions
-    Input: $apply=compute(Amount div aggregate(Budget) as RelativeAmount)
+    Input: $apply=compute(Amount div $these/aggregate(Budget) as RelativeAmount)
 
   - Name: aggregate function - across input set with related custom aggregate
     Rule: queryOptions
-    Input: $apply=compute(Amount div aggregate(Product/Budget) as
+    Input: $apply=compute(Amount div $these/aggregate(Product/Budget) as
       RelativeAmount)
 
   - Name: aggregate function - across input set with from
     Rule: queryOptions
     Input:
-      $apply=compute(Amount div aggregate(Amount with sum from Time
+      $apply=compute(Amount div $these/aggregate(Amount with sum from Time
       with average) as RelativeAmount)
 
   - Name: aggregate function - across input set with $count and from
     Rule: queryOptions
-    Input: $apply=compute(aggregate($count from Product with max) as SalesCount)
+    Input: $apply=compute($these/aggregate($count from Product with max) as SalesCount)
 
   - Name: aggregate function - across input set with $count
     Rule: queryOptions
-    Input: $apply=groupby((Customer),compute(aggregate($count) as
+    Input: $apply=groupby((Customer),compute($these/aggregate($count) as
       SalesCount))/filter(SalesCount ge 2)/aggregate(Amount with sum as
       TotalAmount)
 
   - Name: aggregate function - within a group - ...
     Rule: queryOptions
-    Input: $apply=groupby((Region),compute(aggregate(SalesNumber with
+    Input: $apply=groupby((Region),compute($these/aggregate(SalesNumber with
       average) as RegionAmount))/filter(RegionAmount gt
       150)/concat(groupby((Region),aggregate(SalesNumber with average as
       RegionAmount)),aggregate(SalesNumber with average as TotalAmount))
 
   - Name: aggregate function - in $compute option
     Rule: queryOptions
-    Input: $compute=Amount div aggregate(Amount with sum) as RelativeAmount
+    Input: $compute=Amount div $these/aggregate(Amount with sum) as RelativeAmount
 
   - Name: aggregate function - in $compute option with custom aggregate
     Rule: queryOptions
-    Input: $compute=Amount div aggregate(Budget) as RelativeAmount
+    Input: $compute=Amount div $these/aggregate(Budget) as RelativeAmount
 
-  - Name: aggregate function - within filter and lambda
+  - Name: aggregate function - within filter after navigation property
     Rule: queryOptions
-    FailAt: 36
-    Input: $filter=Products/aggregate(p:p/Sales/Amount with sum) gt 3
+    Input: $filter=Products/aggregate(Sales/Amount with sum) gt 3
 
-  - Name: aggregate function - within filter without lambda
+  - Name: aggregate function - within filter on current collection
     Rule: queryOptions
-    Input: $filter=aggregate(Products/Sales/Amount with sum) gt 3
+    Input: $filter=$these/aggregate(Products/Sales/Amount with sum) gt 3
     Expect:
-      - currCollectionExpr:aggregate(Products/Sales/Amount with sum)
+      - currCollectionExpr:$these/aggregate(Products/Sales/Amount with sum)
 
   - Name: aggregate function - aggregate within any
     Rule: queryOptions
-    Input: $filter=Products/any(p:aggregate(p/Sales/Amount with sum) gt 10)
-
-  - Name: aggregate function - aggregate within any (non-preferred)
-    Rule: queryOptions
-    Input: $filter=Products/any(p:p/Sales/aggregate(s:s/Amount with sum) gt 10)
-    Expect:
-      - aggregateFunArith:s/Amount # unwanted arithmetic
+    Input: $filter=Products/any(p:p/Sales/aggregate(Amount with sum) gt 10)
 
   - Name: aggregate function - countdistinct with navigation property
     Rule: queryOptions
-    Input: $filter=aggregate(Products/Sales with countdistinct) gt 3
+    Input: $filter=$these/aggregate(Products/Sales with countdistinct) gt 3
 
   - Name: aggregate - crossjoin
     Rule: odataRelativeUri
@@ -1070,7 +1036,7 @@ TestCases:
       aggregation methods - $count only allowed on top level, not nested within
       path
     Rule: queryOptions
-    FailAt: 37
+    FailAt: 38
     Input: $apply=groupby((Name),aggregate(Sales($count as SalesCount)))
 
   - Name: collection-valued path

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -273,6 +273,11 @@ TestCases:
     FailAt: 30
     Input: $apply=aggregate(Sales/Amount sub Sales/Cost with sum as TotalAmount)
 
+  - Name: aggregate - forbidden arithmetic with $it
+    Rule: queryOptions
+    FailAt: 28
+    Input: $apply=aggregate(Amount sub $it/Cost with sum as TotalAmount)
+
   - Name: aggregate - allowed arithmetic on collection
     Rule: queryOptions
     Input: $apply=addnested(Sales,compute(Amount sub Cost as Profit) as
@@ -765,14 +770,14 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Sales/aggregate(p:TaxRate mul p/Amount with sum) gt 5
     Expect:
-      - aggregatableFactor:TaxRate
-      - aggregatableFactor:p/Amount
+      - aggregateFunFactor:TaxRate
+      - aggregateFunFactor:p/Amount
 
   - Name: aggregate function - lambda operators
     Rule: queryOptions
     Input: $filter=Products/all(p:p/Sales/any(s:s/Amount gt p/Sales/aggregate(t:t/Amount with average) mul 2))
     Expect:
-      - aggregatableArith:t/Amount
+      - aggregateFunArith:t/Amount
 
   - Name: aggregate function - omit lambda variable only in type 2
     Rule: queryOptions
@@ -787,13 +792,13 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Sales/aggregate(p:Custom.Rating(Article=p/Product) with average) gt 5
     Expect:
-      - aggregatableParam:p/Product
+      - aggregateFunParam:p/Product
 
   - Name: aggregate function - function expression on current collection
     Rule: queryOptions
     Input: $filter=aggregate(Custom.Rating(Article=Product) with average) gt 5
     Expect:
-      - aggregatableParam:Product
+      - aggregateFunParam:Product
 
   - Name: aggregate function - after grouping
     Rule: queryOptions
@@ -871,7 +876,7 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Products/any(p:p/Sales/aggregate(s:s/Amount with sum) gt 10)
     Expect:
-      - aggregatableArith:s/Amount # unwanted arithmetic
+      - aggregateFunArith:s/Amount # unwanted arithmetic
 
   - Name: aggregate function - countdistinct with navigation property
     Rule: queryOptions

--- a/abnf/odata-aggregation-testcases.yaml
+++ b/abnf/odata-aggregation-testcases.yaml
@@ -867,6 +867,12 @@ TestCases:
     Rule: queryOptions
     Input: $filter=Products/any(p:aggregate(p/Sales/Amount with sum) gt 10)
 
+  - Name: aggregate function - aggregate within any (non-preferred)
+    Rule: queryOptions
+    Input: $filter=Products/any(p:p/Sales/aggregate(s:s/Amount with sum) gt 10)
+    Expect:
+      - aggregatableArith:s/Amount # unwanted arithmetic
+
   - Name: aggregate function - countdistinct with navigation property
     Rule: queryOptions
     Input: $filter=aggregate(Products/Sales with countdistinct) gt 3


### PR DESCRIPTION
Aggregate expressions of type 2 are aggregatable expressions as defined in OData-Aggr. Represent them by the `commonExpr` rule in ABNF.

The `aggregate` follows a collection-valued path or `$these` (current collection) and don't use lambda variables.