### PR TITLE
ODATA-1540

### DIFF
--- a/abnf/odata-abnf-construction-rules.txt
+++ b/abnf/odata-abnf-construction-rules.txt
@@ -359,7 +359,7 @@ searchPhrase = quotation-mark 1*( qchar-no-AMP-DQUOTE / SP ) quotation-mark
 ; Expressing this in ABNF is somewhat clumsy, so the following rule is overly generous.
 ; Note: the words AND, OR, and NOT are sometimes operators, depending on their position within a search expression.
 searchWord = searchChar *( searchChar / SQUOTE )
-searchChar = unreserved / pct-encoded-no-DQUOTE / "!" / "*" / "+" / "," / ":" / "@" / "/" / "?" / "$" / "="
+searchChar = unreserved / pct-encoded-no-DQUOTE / "!" / "*" /"+" / "," / ":" / "@" / "/" / "?" / "$" / "="
 
 searchExpr-incomplete = SQUOTE *( SQUOTE-in-string / qchar-no-AMP-SQUOTE / quotation-mark / SP ) SQUOTE
 
@@ -966,7 +966,7 @@ SQUOTE-in-string = SQUOTE SQUOTE ; two consecutive single quotes represent one w
 
 dateValue = year "-" month "-" day
 
-dateTimeOffsetValue      = year "-" month "-" day "T" timeOfDayValue      ( "Z" / SIGN hour ":"   minute )
+dateTimeOffsetValue      = year "-" month "-" day "T" timeOfDayValue      ( "Z" / ( "+" / "-" ) hour ":"   minute )
 dateTimeOffsetValueInUrl = year "-" month "-" day "T" timeOfDayValueInUrl ( "Z" / SIGN hour COLON minute )
 
 duration      = [ "duration" ] SQUOTE durationValue SQUOTE
@@ -1146,7 +1146,7 @@ COLON  = ":" / "%3A"
 COMMA  = "," / "%2C"
 EQ     = "="
 HASH   = "%23" ; the # character is not allowed in the query part
-SIGN   = "+" / "%2B" / "-"
+SIGN   = "%2B" / "-"
 SEMI   = ";" / "%3B"
 STAR   = "*" / "%2A"
 SQUOTE = "'" / "%27"

--- a/abnf/odata-abnf-testcases.yaml
+++ b/abnf/odata-abnf-testcases.yaml
@@ -431,7 +431,7 @@ TestCases:
 
   - Name: "DateTimeOffset: with percent-encoding"
     Rule: dateTimeOffsetValueInUrl
-    Input: 2012-09-03T23%3A59+01%3A00
+    Input: 2012-09-03T23%3A59%2B01%3A00
 
   - Name: Decimal
     Rule: decimalValue
@@ -479,14 +479,18 @@ TestCases:
     Rule: duration
     Input: "'P6DT23H59M59.9999S'"
 
-  - Name: "Decimal: integer"
+  - Name: Decimal - negative integer
     Rule: decimalValue
     Input: "-2"
 
-  - Name: "Decimal: integer"
+  - Name: Decimal - positive integer
     Rule: decimalValue
-    FailAt: 4
-    Input: "+42."
+    Input: "%2B42"
+
+  - Name: Decimal - trailing dot
+    Rule: decimalValue
+    FailAt: 3
+    Input: "42."
 
   - Name: "Decimal: no digit before decimal point"
     Rule: decimalValue
@@ -540,7 +544,11 @@ TestCases:
 
   - Name: Int16
     Rule: int16Value
-    Input: "+32000"
+    Input: "32000"
+
+  - Name: Int16
+    Rule: int16Value
+    Input: "%2B32000"
 
   - Name: Int32
     Rule: int32Value


### PR DESCRIPTION
- [ ] rule `primitiveValue`: use literal `+` instead of `%2B` as optional sign for numbers
- [ ] rule `string`: no percent-encoding
- [ ] reuse these changes for #106 